### PR TITLE
feat(KAF): support the layout config

### DIFF
--- a/src/_internal/molecules/AutoForm/ObjectField.tsx
+++ b/src/_internal/molecules/AutoForm/ObjectField.tsx
@@ -14,6 +14,7 @@ export function resolveSubFields(props: WidgetProps) {
     props;
   const fields: Field[] = field?.fields || [];
   const properties = Object.keys(spec.properties || {});
+  const isLayout = field?.type === "layout";
 
   if (fields.length) {
     // if configure the sub fields then use them
@@ -47,13 +48,17 @@ export function resolveSubFields(props: WidgetProps) {
             ...subSpec,
             title: subField.label,
           }}
-          path={path.concat(`.${subField.path}`)}
+          path={path.concat(isLayout ? subField.path : `.${subField.path}`)}
           level={level + 1}
           value={get(value, subField.path)}
-          onChange={(newValue, key, dataPath) => {
-            const result = immutableSet(value, subField.path, newValue);
-
-            onChange(result, key, dataPath);
+          onChange={(newValue, displayValues, key, dataPath) => {
+            if (isLayout) {
+              onChange(newValue, displayValues, key, dataPath);
+            } else {
+              const result = immutableSet(value, subField.path, newValue);
+  
+              onChange(result, displayValues, key, dataPath);
+            }
           }}
         />
       );

--- a/src/_internal/molecules/AutoForm/ObjectField.tsx
+++ b/src/_internal/molecules/AutoForm/ObjectField.tsx
@@ -7,9 +7,11 @@ import { immutableSet } from "../../../editor/utils/object";
 import { get } from "lodash";
 import type { Field } from "../../organisms/KubectlApplyForm/type";
 import { isObject } from "lodash";
+import { JSONSchema7 } from "json-schema";
 
 export function resolveSubFields(props: WidgetProps) {
-  const { field, spec, value, path, level, error, onChange } = props;
+  const { fieldsArray, field, spec, value, path, level, error, onChange } =
+    props;
   const fields: Field[] = field?.fields || [];
   const properties = Object.keys(spec.properties || {});
 
@@ -18,8 +20,16 @@ export function resolveSubFields(props: WidgetProps) {
     return fields.map((subField) => {
       if (!subField.path) return null;
 
-      const subSpec = getJsonSchemaByPath(spec, subField.path) || {};
+      let subSpec: JSONSchema7 | null = {};
       const errorInfo = subField?.error || error;
+
+      if (field?.path) {
+        subSpec = getJsonSchemaByPath(spec, subField.path);
+      } else {
+        const [index, ...subPath] = subField.path.split(".");
+
+        subSpec = fieldsArray[Number(index)]?.[subPath.join(".")].spec || {};
+      }
 
       return (
         <SpecField

--- a/src/_internal/molecules/AutoForm/SpecField.tsx
+++ b/src/_internal/molecules/AutoForm/SpecField.tsx
@@ -17,6 +17,7 @@ import {
   FORM_WIDGETS_MAP,
   FORM_WIDGET_OPTIONS_MAP,
 } from "../../molecules/form";
+import { LAYOUT_WIDGETS_MAP } from "../../molecules/layout";
 import { Typo } from "../../atoms/themes/CloudTower/styles/typo.style";
 import { Static } from "@sinclair/typebox";
 
@@ -185,6 +186,7 @@ type SpecFieldProps = WidgetProps & {
 const SpecField: React.FC<SpecFieldProps> = (props) => {
   const {
     services,
+    fieldsArray,
     basePath,
     field,
     spec,
@@ -207,7 +209,10 @@ const SpecField: React.FC<SpecFieldProps> = (props) => {
   let { widgetOptions = {} } = props;
   const { title } = spec;
   const label = title ?? "";
-  const displayLabel = field?.isDisplayLabel ?? shouldDisplayLabel(spec, label);
+  const displayLabel =
+    field?.type === "layout"
+      ? field.indent
+      : field?.isDisplayLabel ?? shouldDisplayLabel(spec, label);
   const displayDescription = shouldDisplayDescdisplayDescription(spec);
 
   if (isEmpty(spec) || field?.condition === false) {
@@ -218,8 +223,15 @@ const SpecField: React.FC<SpecFieldProps> = (props) => {
   let isNest = false;
 
   // type fields
-  if (widget && widget in FORM_WIDGETS_MAP) {
+  if (widget && widget in FORM_WIDGETS_MAP && field?.type !== "layout") {
     Component = FORM_WIDGETS_MAP[widget as keyof typeof FORM_WIDGETS_MAP];
+  } else if (
+    field?.type === "layout" &&
+    field.layoutWidget &&
+    field.layoutWidget in LAYOUT_WIDGETS_MAP
+  ) {
+    Component =
+      LAYOUT_WIDGETS_MAP[field.layoutWidget as keyof typeof LAYOUT_WIDGETS_MAP];
   } else if (field?.path.includes("metadata.namespace")) {
     Component = FORM_WIDGETS_MAP.k8sSelect;
     widgetOptions = {
@@ -252,6 +264,7 @@ const SpecField: React.FC<SpecFieldProps> = (props) => {
   const FieldComponent = (
     <Component
       services={services}
+      fieldsArray={fieldsArray}
       widgetOptions={widgetOptions}
       error={typeof error !== "string" ? error : undefined}
       field={field}

--- a/src/_internal/molecules/AutoForm/SpecField.tsx
+++ b/src/_internal/molecules/AutoForm/SpecField.tsx
@@ -26,7 +26,7 @@ type TemplateProps = {
   label?: string;
   layout?: "horizontal" | "vertical";
   error?: string;
-  description?: string;
+  description?: React.ReactNode;
   hidden?: boolean;
   required?: boolean;
   displayLabel?: boolean;
@@ -85,6 +85,7 @@ const FormItemStyle = css`
 
   .dovetail-ant-form-item-control {
     flex: 1;
+    min-width: 0;
   }
 
   .dovetail-ant-form-item-extra {
@@ -125,13 +126,10 @@ const DefaultTemplate: React.FC<TemplateProps> = (props) => {
     error,
     description,
     hidden,
-    required,
     displayLabel,
     labelWidth,
     displayDescription,
-    spec,
   } = props;
-  const isHorizontal = layout === "horizontal" || layout === undefined;
 
   if (hidden) {
     return <div className="hidden">{children}</div>;
@@ -144,7 +142,7 @@ const DefaultTemplate: React.FC<TemplateProps> = (props) => {
       label={
         displayLabel ? (
           <span
-            style={{ width: labelWidth || 108 + "px" }}
+            style={{ width: labelWidth || `${108}px` }}
             className={cx(Typo.Label.l3_regular_title, FormItemLabelStyle)}
           >
             {label}
@@ -172,7 +170,7 @@ function shouldDisplayLabel(spec: JSONSchema7, label: string): boolean {
   return true;
 }
 
-function shouldDisplayDescdisplayDescription(spec: JSONSchema7): boolean {
+function shouldDisplayDescription(spec: JSONSchema7): boolean {
   if (spec.type === "object") {
     return false;
   }
@@ -213,7 +211,7 @@ const SpecField: React.FC<SpecFieldProps> = (props) => {
     field?.type === "layout"
       ? field.indent
       : field?.isDisplayLabel ?? shouldDisplayLabel(spec, label);
-  const displayDescription = shouldDisplayDescdisplayDescription(spec);
+  const displayDescription = shouldDisplayDescription(spec);
 
   if (isEmpty(spec) || field?.condition === false) {
     return null;
@@ -263,6 +261,7 @@ const SpecField: React.FC<SpecFieldProps> = (props) => {
 
   const FieldComponent = (
     <Component
+      basePath={basePath}
       services={services}
       fieldsArray={fieldsArray}
       widgetOptions={widgetOptions}

--- a/src/_internal/molecules/AutoForm/get-fields.tsx
+++ b/src/_internal/molecules/AutoForm/get-fields.tsx
@@ -1,21 +1,9 @@
-import React from "react";
 import { JSONSchema7 } from "json-schema";
 import { WidgetProps } from "./widget";
-import UnsupportedField from "./UnsupportedField";
-import StringField from "./StringField";
-import ArrayField, { AddToArrayField } from "./ArrayField";
-import BooleanField from "./BooleanField";
-import NumberField from "./NumberField";
-import NullField from "./NullField";
-import ObjectField from "./ObjectField";
-import MultiSpecField from "./MultiSpecField";
 
-export function getFields(
-  spec: JSONSchema7
-): Record<
+export function getFields(spec: JSONSchema7): Record<
   string,
   {
-    Component: React.FC<WidgetProps>;
     spec: JSONSchema7;
   }
 > {
@@ -33,9 +21,7 @@ type RecursiveContext = {
 };
 
 function recursiveGetFields(spec: JSONSchema7, ctx: RecursiveContext) {
-  let Component = UnsupportedField;
   if (spec.type === "object") {
-    Component = ObjectField;
     const properties = Object.keys(spec.properties || {});
     for (const name of properties) {
       const subSpec = (spec.properties || {})[name] as WidgetProps["spec"];
@@ -47,32 +33,20 @@ function recursiveGetFields(spec: JSONSchema7, ctx: RecursiveContext) {
       }
     }
   } else if (spec.type === "string") {
-    Component = StringField;
   } else if (spec.type === "array") {
-    Component = ArrayField;
     const itemSpec = Array.isArray(spec.items) ? spec.items[0] : spec.items;
     if (itemSpec && typeof itemSpec === "object") {
       recursiveGetFields(itemSpec, {
         ...ctx,
-        path: ctx.path.concat(ctx.path ? `.$i` : '$i'),
+        path: ctx.path.concat(ctx.path ? ".$i" : "$i"),
       });
     }
-    ctx.fields[ctx.path.concat(ctx.path ? `.$add` : '$add')] = {
-      Component: AddToArrayField,
+    ctx.fields[ctx.path.concat(ctx.path ? ".$add" : "$add")] = {
       spec,
     };
-  } else if (spec.type === "boolean") {
-    Component = BooleanField;
-  } else if (spec.type === "integer" || spec.type === "number") {
-    Component = NumberField;
-  } else if (spec.type === "null") {
-    Component = NullField;
-  } else if ("anyOf" in spec || "oneOf" in spec) {
-    Component = MultiSpecField;
   }
 
   ctx.fields[ctx.path || "*"] = {
-    Component,
     spec,
   };
 }

--- a/src/_internal/molecules/AutoForm/widget.ts
+++ b/src/_internal/molecules/AutoForm/widget.ts
@@ -35,4 +35,5 @@ export type WidgetProps<Value = any, WidgetOptions = Record<string, any>> = {
   onDisplayValuesChange: (displayValues: Record<string, any>) => void;
   slot?: Function;
   helperSlot?: Function;
+  fieldsArray: Record<string, { spec: JSONSchema7 }>[];
 };

--- a/src/_internal/molecules/AutoForm/widget.ts
+++ b/src/_internal/molecules/AutoForm/widget.ts
@@ -1,5 +1,5 @@
 import { JSONSchema7 } from "json-schema";
-import type { Field, Services } from "../../organisms/KubectlApplyForm/type";
+import type { Field, Services, FormItemData } from "../../organisms/KubectlApplyForm/type";
 
 type WidgetOptions = Partial<{
   displayLabel: boolean;
@@ -7,7 +7,16 @@ type WidgetOptions = Partial<{
   step?: number;
 }>;
 
-export type WidgetProps<Value = any, WidgetOptions = Record<string, any>> = {
+type SlotFunction = (
+  props: FormItemData,
+  fallback: React.ReactNode,
+  key: string
+) => React.ReactNode;
+
+export type WidgetProps<
+  Value = any,
+  WidgetOptions = Record<string, unknown>
+> = {
   services: Services;
   basePath: string;
   field?: Field;
@@ -25,15 +34,15 @@ export type WidgetProps<Value = any, WidgetOptions = Record<string, any>> = {
   index?: number;
   error?: string | string[] | Record<string, string>;
   value: Value;
-  displayValues: Record<string, any>;
+  displayValues: Record<string, unknown>;
   onChange: (
     newValue: Value,
-    displayValues: Record<string, any>,
+    displayValues: Record<string, unknown>,
     key?: string,
     dataPath?: string
   ) => void;
-  onDisplayValuesChange: (displayValues: Record<string, any>) => void;
-  slot?: Function;
-  helperSlot?: Function;
+  onDisplayValuesChange: (displayValues: Record<string, unknown>) => void;
+  slot?: SlotFunction;
+  helperSlot?: SlotFunction;
   fieldsArray: Record<string, { spec: JSONSchema7 }>[];
 };

--- a/src/_internal/molecules/DefaultLayout.tsx
+++ b/src/_internal/molecules/DefaultLayout.tsx
@@ -2,6 +2,13 @@ import { Type, Static } from "@sinclair/typebox";
 import { WidgetProps } from "./AutoForm/widget";
 import { resolveSubFields } from "./AutoForm/ObjectField";
 import React from "react";
+import { Row } from "antd";
+import { css } from "@emotion/css";
+
+const GroupBodyStyle = css`
+  padding-bottom: 0;
+  margin: 0;
+`;
 
 export const OptionsSpec = Type.Object({});
 
@@ -11,7 +18,11 @@ type DefaultLayoutProps = WidgetProps<
 >;
 
 const DefaultLayout = (props: DefaultLayoutProps) => {
-  return <div>{resolveSubFields(props)}</div>;
+  return (
+    <Row className={GroupBodyStyle} gutter={[24, 16]} style={{ margin: "-8px -12px" }}>
+      {resolveSubFields(props)}
+    </Row>
+  );
 };
 
 export default DefaultLayout;

--- a/src/_internal/molecules/DefaultLayout.tsx
+++ b/src/_internal/molecules/DefaultLayout.tsx
@@ -1,0 +1,17 @@
+import { Type, Static } from "@sinclair/typebox";
+import { WidgetProps } from "./AutoForm/widget";
+import { resolveSubFields } from "./AutoForm/ObjectField";
+import React from "react";
+
+export const OptionsSpec = Type.Object({});
+
+type DefaultLayoutProps = WidgetProps<
+  Record<string, any>,
+  Static<typeof OptionsSpec>
+>;
+
+const DefaultLayout = (props: DefaultLayoutProps) => {
+  return <div>{resolveSubFields(props)}</div>;
+};
+
+export default DefaultLayout;

--- a/src/_internal/molecules/form.ts
+++ b/src/_internal/molecules/form.ts
@@ -1,3 +1,4 @@
+import Group, { OptionsSpec as GroupOptionsSpec } from "./Group";
 import Input, { OptionsSpec as InputOptionsSpec } from "./Input";
 import Select, { OptionsSpec as SelectOptionsSpec } from "./Select";
 import Textarea, { OptionsSpec as TextareaOptionsSpec } from "./Textarea";
@@ -18,6 +19,7 @@ export const FORM_WIDGETS_MAP = {
   card: Card,
   arrayCards: ArrayCards,
   k8sSelect: K8sSelect,
+  group: Group,
 };
 export const FORM_WIDGET_OPTIONS_MAP = {
   input: InputOptionsSpec,
@@ -28,4 +30,5 @@ export const FORM_WIDGET_OPTIONS_MAP = {
   card: CardOptionsSpec,
   arrayCards: ArrayCardsOptionsSpec,
   k8sSelect: K8sSelectOptionsSpec,
+  group: GroupOptionsSpec,
 };

--- a/src/_internal/molecules/layout.ts
+++ b/src/_internal/molecules/layout.ts
@@ -1,0 +1,16 @@
+import Group, { OptionsSpec as GroupOptionsSpec } from "./Group";
+import Card, { OptionsSpec as CardOptionsSpec } from "./Card";
+import DefaultLayout, {
+  OptionsSpec as DefaultLayoutOptionsSpec,
+} from "./DefaultLayout";
+
+export const LAYOUT_WIDGETS_MAP = {
+  default: DefaultLayout,
+  card: Card,
+  group: Group,
+};
+export const LAYOUT_WIDGET_OPTIONS_MAP = {
+  card: CardOptionsSpec,
+  group: GroupOptionsSpec,
+  default: DefaultLayoutOptionsSpec,
+};

--- a/src/_internal/organisms/KubectlApplyForm/KubectlApplyForm.tsx
+++ b/src/_internal/organisms/KubectlApplyForm/KubectlApplyForm.tsx
@@ -1,8 +1,6 @@
 import { JSONSchema7 } from "json-schema";
 import React, { useContext, useMemo, useState, useRef } from "react";
-import get from "lodash/get";
 import set from "lodash/set";
-import groupBy from "lodash/groupBy";
 import { getFields } from "../../molecules/AutoForm/get-fields";
 import CodeEditor from "../../atoms/CodeEditor";
 import yaml, { dump } from "js-yaml";
@@ -14,7 +12,7 @@ import {
   WizardStyle,
 } from "./KubectlApplyForm.style";
 import { cx, css as dCss } from "@emotion/css";
-import { Steps, Popover, Row, Alert } from "antd";
+import { Steps, Row, Alert } from "antd";
 import { CheckOutlined } from "@ant-design/icons";
 import SpecField from "../../molecules/AutoForm/SpecField";
 import Icon from "../../atoms/themes/CloudTower/components/Icon/Icon";
@@ -41,6 +39,7 @@ import {
   Services,
   Events,
   Store,
+  FormItemData
 } from "./type";
 import { transformFields } from "./utils";
 import mitt from "mitt";
@@ -62,9 +61,9 @@ export type KubectlApplyFormProps = {
     confirmText: string;
     cancelText: string;
   };
-  values: any[];
-  defaultValues: any[];
-  displayValues: Record<string, any>;
+  values: unknown[];
+  defaultValues: unknown[];
+  displayValues: Record<string, unknown>;
   error?: string;
   errorDetail?: {
     title: string;
@@ -74,24 +73,24 @@ export type KubectlApplyFormProps = {
   step: number;
   setStep: (step: number) => void;
   getSlot?: (
-    f: Field & { index?: number },
+    field: FormItemData,
     fallback: React.ReactNode,
     slotKey: string
   ) => React.ReactNode;
   getHelperSlot?: (
-    f: Field & { index?: number },
+    field: FormItemData,
     fallback: React.ReactNode,
     slotKey: string
   ) => React.ReactNode;
   onChange: (
-    values: any[],
-    displayValues: Record<string, any>,
+    values: unknown[],
+    displayValues: Record<string, unknown>,
     key?: string,
     dataPath?: string
   ) => void;
-  onDisplayValuesChange: (displayValues: Record<string, any>) => void;
-  onNextStep?: (values: any[]) => void;
-  onSubmit?: (values: any[]) => void;
+  onDisplayValuesChange: (displayValues: Record<string, unknown>) => void;
+  onNextStep?: (values: unknown[]) => void;
+  onSubmit?: (values: unknown[]) => void;
   onCancel?: () => void;
 };
 
@@ -99,7 +98,7 @@ const KubectlApplyForm = React.forwardRef<
   HTMLDivElement,
   KubectlApplyFormProps
 >(
-  (
+  function KubectlApplyForm(
     {
       basePath,
       className,
@@ -122,7 +121,7 @@ const KubectlApplyForm = React.forwardRef<
       onSubmit,
     },
     ref
-  ) => {
+  ) {
     const [yamlMode, setYamlMode] = useState(false);
     const fieldsArray = useMemo(() => {
       return schemas.map((s) => getFields(s));
@@ -149,11 +148,12 @@ const KubectlApplyForm = React.forwardRef<
       const [indexStr, path] = f.path.split(/\.(.*)/s);
       const index = parseInt(indexStr, 10);
       const { spec } = fieldsArray?.[index]?.[path] || {};
+      const isLayout = f.type === "layout";
 
       const component = (
         <SpecField
-          services={services}
           key={f.dataPath || f.key}
+          services={services}
           basePath={basePath}
           field={f}
           error={f.error}
@@ -164,21 +164,22 @@ const KubectlApplyForm = React.forwardRef<
           level={0}
           path={f.dataPath}
           stepElsRef={{}}
-          value={f.value}
+          value={isLayout ? values : f.value}
           displayValues={displayValues}
           slot={getSlot}
           helperSlot={getHelperSlot}
           onChange={(
-            newValue: any,
-            displayValue: any,
+            newValue: unknown,
+            displayValue: Record<string, unknown>,
             key?: string,
             dataPath?: string
           ) => {
-            const valuesSlice = [...values];
-            set(valuesSlice, f.dataPath, newValue);
+            const valuesSlice: unknown[] = [...values];
+
+            set(valuesSlice, isLayout ? dataPath || "" : f.dataPath, newValue);
             onChange(valuesSlice, displayValue, key, dataPath);
           }}
-          onDisplayValuesChange={(displayValues: Record<string, any>) => {
+          onDisplayValuesChange={(displayValues: Record<string, unknown>) => {
             onDisplayValuesChange(displayValues);
           }}
         />
@@ -201,7 +202,7 @@ const KubectlApplyForm = React.forwardRef<
               </div>
               {errorDetail.errors.map((errorInfo, index) => (
                 <div className={Typo.Label.l4_regular} key={errorInfo}>{`${
-                  errorDetail.errors.length > 1 ? index + 1 + "." : ""
+                  errorDetail.errors.length > 1 ? `${index + 1}.` : ""
                 } ${errorInfo}`}</div>
               ))}
             </>
@@ -281,27 +282,30 @@ const KubectlApplyForm = React.forwardRef<
         }
         case "tabs": {
           return (
-            <Tabs isLazy>
-              <TabList>
-                {layout.tabs.map((t, idx) => {
-                  return <Tab key={t.title + idx}>{t.title}</Tab>;
-                })}
-              </TabList>
-              <TabPanels>
-                {layout.tabs.map((t, idx) => {
-                  return (
-                    <TabPanel key={t.title + idx}>
-                      {transformFields(t.fields, values, defaultValues).map(
-                        (f) => {
-                          const { component } = getComponent(f);
-                          return component;
-                        }
-                      )}
-                    </TabPanel>
-                  );
-                })}
-              </TabPanels>
-            </Tabs>
+            <>
+              <Tabs isLazy>
+                <TabList>
+                  {layout.tabs.map((t, idx) => {
+                    return <Tab key={`${t.title}-${idx}`}>{t.title}</Tab>;
+                  })}
+                </TabList>
+                <TabPanels>
+                  {layout.tabs.map((t, idx) => {
+                    return (
+                      <TabPanel key={`${t.title}-${idx}`}>
+                        {transformFields(t.fields, values, defaultValues).map(
+                          (f) => {
+                            const { component } = getComponent(f);
+
+                            return component;
+                          }
+                        )}
+                      </TabPanel>
+                    );
+                  })}
+                </TabPanels>
+              </Tabs>
+            </>
           );
         }
         case "wizard": {
@@ -321,7 +325,7 @@ const KubectlApplyForm = React.forwardRef<
                   >
                     {(layout.steps || []).map((s, idx) => (
                       <Steps.Step
-                        key={s.title + idx}
+                        key={`${s.title}-${idx}`}
                         title={
                           <>
                             {idx >= step ? (

--- a/src/_internal/organisms/KubectlApplyForm/KubectlApplyForm.tsx
+++ b/src/_internal/organisms/KubectlApplyForm/KubectlApplyForm.tsx
@@ -160,6 +160,7 @@ const KubectlApplyForm = React.forwardRef<
           widget={f.widget}
           widgetOptions={f.widgetOptions}
           spec={{ ...spec, title: f.label }}
+          fieldsArray={fieldsArray}
           level={0}
           path={f.dataPath}
           stepElsRef={{}}

--- a/src/_internal/organisms/KubectlApplyForm/type.ts
+++ b/src/_internal/organisms/KubectlApplyForm/type.ts
@@ -30,6 +30,8 @@ export type Field = {
   };
 };
 
+export type FormItemData = (Field | Record<string, unknown>) & { index?: number; };
+
 export type TransformedField = Field & { dataPath: string; value: any };
 
 export type Layout =

--- a/src/_internal/organisms/KubectlApplyForm/type.ts
+++ b/src/_internal/organisms/KubectlApplyForm/type.ts
@@ -1,6 +1,7 @@
 import { Emitter } from "mitt";
 
 export type Field = {
+  type?: "field" | "layout";
   fields?: Field[];
   path: string;
   key?: string;
@@ -13,6 +14,8 @@ export type Field = {
   error: string | string[] | Record<string, string>;
   condition?: boolean;
   widget?: string;
+  layoutWidget?: string;
+  indent?: boolean;
   widgetOptions?: Record<string, any>;
   componentId?: string;
   col?: number;

--- a/src/_internal/organisms/KubectlApplyForm/utils.ts
+++ b/src/_internal/organisms/KubectlApplyForm/utils.ts
@@ -24,7 +24,7 @@ function iterateArrPath(
       itemDataPath,
       itemValue,
     });
-    
+
     return;
   }
   const [arrPath] = arrPathMatch;
@@ -73,6 +73,7 @@ export function transformFields(
   defaultValues: any[]
 ): TransformedField[] {
   const newFields = [];
+
   for (const f of fields) {
     if (f.path.includes(".$i")) {
       iterateArrPath(f.path, values, ({ itemDataPath, itemValue }) => {
@@ -84,11 +85,22 @@ export function transformFields(
       });
     } else {
       const dataPath = getDataPath(f.path);
+      const isLayout = f.type === "layout";
+      const value = get(values, dataPath);
+      const defaultValue = get(defaultValues, dataPath);
+
       newFields.push({
         ...f,
         dataPath,
-        value: get(values, dataPath),
-        defaultValue: get(defaultValues, dataPath),
+        value,
+        defaultValue,
+        fields: f.fields
+          ? transformFields(
+              f.fields,
+              isLayout ? values : value,
+              isLayout ? defaultValues : defaultValue
+            )
+          : f.fields,
       });
     }
   }

--- a/src/editor/widgets/k8s/KubectlApplyForm/KubectlApplyFormFieldWidget.tsx
+++ b/src/editor/widgets/k8s/KubectlApplyForm/KubectlApplyFormFieldWidget.tsx
@@ -5,11 +5,9 @@ import {
 import React, { useMemo } from "react";
 import { omit } from "lodash";
 import { Type } from "@sinclair/typebox";
-import { getJsonSchemaByPath } from 'src/_internal/utils/schema';
-import {
-  mergeWidgetOptionsByPath,
-} from "../../../utils/schema";
-import { JSONSchema7 } from 'json-schema';
+import { getJsonSchemaByPath } from "src/_internal/utils/schema";
+import { mergeWidgetOptionsByPath } from "../../../utils/schema";
+import { JSONSchema7 } from "json-schema";
 import { getFields } from "src/_internal/molecules/AutoForm/get-fields";
 
 export default implementWidget<"kui/v1/KubectlApplyFormFieldWidget">({
@@ -24,8 +22,9 @@ export default implementWidget<"kui/v1/KubectlApplyFormFieldWidget">({
   },
 })(function KubectlApplyFormFieldWidget(props) {
   const parentPath = props.spec.widgetOptions?.parentPath || "";
-  const applyFormSchemas = useMemo(() => {
-    return (props.component.properties.formConfig as any).schemas;
+  const applyFormSchemas = useMemo<JSONSchema7[]>(() => {
+    return (props.component.properties.formConfig as any)
+      .schemas as JSONSchema7[];
   }, [props.component]);
   const spec = useMemo(() => {
     let spec: JSONSchema7 = props.spec;
@@ -35,26 +34,28 @@ export default implementWidget<"kui/v1/KubectlApplyFormFieldWidget">({
         props.value.path
       }`.split(".");
       const applyFormSchema = getJsonSchemaByPath(
-        applyFormSchemas[index],
+        applyFormSchemas[Number(index)],
         path.join(".")
       );
       const isArraySchema =
         applyFormSchema?.type === "array" &&
         (applyFormSchema?.items as JSONSchema7)?.type === "object";
+      const subPaths = applyFormSchema
+        ? Object.keys(getFields(applyFormSchema)).map((subPath) =>
+            // if it is the array schema, then the sub path should remove the `$add` or the `$i`
+            isArraySchema ? subPath.split(".").slice(1).join(".") : subPath
+          )
+        : [];
 
       if (
         applyFormSchema &&
         (applyFormSchema.type === "object" || isArraySchema)
       ) {
-        const paths = Object.keys(getFields(applyFormSchema)).map((subPath) =>
-          isArraySchema ? subPath.split(".").slice(1).join(".") : subPath
-        );
-
         spec = mergeWidgetOptionsByPath(spec, "fields.$i", {
           parentPath: props.value.path,
         });
         spec = mergeWidgetOptionsByPath(spec, "fields.$i.path", {
-          paths,
+          paths: subPaths,
         });
         spec = mergeWidgetOptionsByPath(spec, "fields.$i.componentId", {
           parentPath: props.value.path,
@@ -62,13 +63,34 @@ export default implementWidget<"kui/v1/KubectlApplyFormFieldWidget">({
 
         return spec;
       }
+    } else if (props.value.type === "layout") {
+      const subPaths: string[] = applyFormSchemas
+        .map((applyFormSchema, index) =>
+          Object.keys(getFields(applyFormSchema)).map(
+            (subPath) => `${index}.${subPath}`
+          )
+        )
+        .flat();
+
+      spec = mergeWidgetOptionsByPath(spec, "fields.$i", {
+        parentPath: props.value.path,
+      });
+      spec = mergeWidgetOptionsByPath(spec, "fields.$i.path", {
+        paths: subPaths,
+      });
+      spec = mergeWidgetOptionsByPath(spec, "fields.$i.componentId", {
+        parentPath: props.value.path,
+      });
+      spec = mergeWidgetOptionsByPath(spec, "widget", {});
+
+      return spec;
     }
 
     return {
       ...spec,
       properties: omit(spec.properties, "fields"),
     };
-  }, [props.spec, props.value, applyFormSchemas]);
+  }, [props.spec, props.value, applyFormSchemas, parentPath]);
 
   return <ObjectField {...props} spec={spec}></ObjectField>;
 });

--- a/src/sunmao/components/KubectlApplyForm.tsx
+++ b/src/sunmao/components/KubectlApplyForm.tsx
@@ -13,32 +13,66 @@ import {
   FORM_WIDGETS_MAP,
   FORM_WIDGET_OPTIONS_MAP,
 } from "../../_internal/molecules/form";
-import { KubeApi, KubeSdk } from "../../_internal/k8s-api-client/kube-api";
+import { LAYOUT_WIDGETS_MAP } from "../../_internal/molecules/layout";
+import { KubeSdk } from "../../_internal/k8s-api-client/kube-api";
 import { generateSlotChildren } from "../utils/slot";
 
+const FIELD_CONDITIONS = [
+  {
+    or: [
+      {
+        key: "type",
+        value: "field",
+      },
+      {
+        key: "type",
+        value: undefined as any,
+      },
+    ],
+  },
+];
+const LAYOUT_CONDITION = [
+  {
+    key: "type",
+    value: "layout",
+  },
+];
+
 const UiConfigFieldSpecProperties = {
+  type: StringUnion(["field", "layout"]),
   path: Type.String({
     title: "Path",
     widget: "kui/v1/PathWidget",
+    conditions: FIELD_CONDITIONS,
   }),
   key: Type.String({
     title: "Key",
     description: "Use for the `latestChangedKey` state",
+    conditions: FIELD_CONDITIONS,
   }),
-  label: Type.String({ title: "Label" }),
+  label: Type.String({ title: "Label", conditions: FIELD_CONDITIONS }),
   labelWidth: Type.Number({
     title: "Label Width",
+    conditions: FIELD_CONDITIONS,
   }),
   isDisplayLabel: Type.Boolean({
     title: "Is display label",
+    conditions: FIELD_CONDITIONS,
   }),
-  layout: StringUnion(["horizontal", "vertical"], { title: "Layout" }),
-  helperText: Type.String({ title: "Helper text" }),
+  layout: StringUnion(["horizontal", "vertical"], {
+    title: "Layout",
+    conditions: FIELD_CONDITIONS,
+  }),
+  helperText: Type.String({
+    title: "Helper text",
+    conditions: FIELD_CONDITIONS,
+  }),
   sectionTitle: Type.String({ title: "Section title" }),
-  error: Type.String({ title: "Error" }),
+  error: Type.String({ title: "Error", conditions: FIELD_CONDITIONS }),
   condition: Type.Boolean({ title: "Condition" }),
   col: Type.Number({
     title: "Col",
+    conditions: FIELD_CONDITIONS,
   }),
   splitLine: Type.Boolean({
     title: "Split line",
@@ -47,8 +81,17 @@ const UiConfigFieldSpecProperties = {
     ["default", "component"].concat(Object.keys(FORM_WIDGETS_MAP)),
     {
       title: "Widget",
+      conditions: FIELD_CONDITIONS,
     }
   ),
+  layoutWidget: StringUnion(Object.keys(LAYOUT_WIDGETS_MAP), {
+    title: "Layout Widget",
+    conditions: LAYOUT_CONDITION,
+  }),
+  indent: Type.Boolean({
+    title: "Indent",
+    conditions: LAYOUT_CONDITION,
+  }),
   widgetOptions: Type.Record(Type.String(), Type.Any(), {
     title: "Widget options",
     widget: "kui/v1/OptionsWidget",

--- a/src/sunmao/components/KubectlApplyForm.tsx
+++ b/src/sunmao/components/KubectlApplyForm.tsx
@@ -8,6 +8,7 @@ import set from "lodash/set";
 import cloneDeep from "lodash/cloneDeep";
 import isEqual from "lodash/isEqual";
 import _KubectlApplyForm from "../../_internal/organisms/KubectlApplyForm/KubectlApplyForm";
+import { FormItemData } from "../../_internal/organisms/KubectlApplyForm/type";
 import { css } from "@emotion/css";
 import {
   FORM_WIDGETS_MAP,
@@ -39,7 +40,6 @@ const LAYOUT_CONDITION = [
 ];
 
 const UiConfigFieldSpecProperties = {
-  type: StringUnion(["field", "layout"]),
   path: Type.String({
     title: "Path",
     widget: "kui/v1/PathWidget",
@@ -84,10 +84,6 @@ const UiConfigFieldSpecProperties = {
       conditions: FIELD_CONDITIONS,
     }
   ),
-  layoutWidget: StringUnion(Object.keys(LAYOUT_WIDGETS_MAP), {
-    title: "Layout Widget",
-    conditions: LAYOUT_CONDITION,
-  }),
   indent: Type.Boolean({
     title: "Indent",
     conditions: LAYOUT_CONDITION,
@@ -124,6 +120,11 @@ const UiConfigFieldSpecProperties = {
 const UiConfigFieldSpec = Type.Object(
   {
     ...UiConfigFieldSpecProperties,
+    type: StringUnion(["field", "layout"], { title: "Choose Config" }),
+    layoutWidget: StringUnion(Object.keys(LAYOUT_WIDGETS_MAP), {
+      title: "Layout Widget",
+      conditions: LAYOUT_CONDITION,
+    }),
     fields: Type.Array(Type.Object(UiConfigFieldSpecProperties), {
       title: "Fields",
       widget: "core/v1/array",
@@ -520,7 +521,7 @@ export const KubectlApplyForm = implementRuntimeComponent({
         onNextStep={callbackMap?.onNextStep}
         onSubmit={callbackMap?.onSubmit}
         onCancel={callbackMap?.onCancel}
-        getSlot={(f, fallback, slotKey) => {
+        getSlot={(field: FormItemData, fallback, slotKey) => {
           return (
             generateSlotChildren(
               {
@@ -534,18 +535,18 @@ export const KubectlApplyForm = implementRuntimeComponent({
               },
               {
                 generateId(child) {
-                  return f.index !== undefined
-                    ? `${child.id}_${f.index}`
+                  return field.index !== undefined
+                    ? `${child.id}_${field.index}`
                     : child.id;
                 },
                 generateProps() {
-                  return (f as Static<typeof UiConfigFieldSpec>) || {};
+                  return (field as Static<typeof UiConfigFieldSpec>) || {};
                 },
               }
             ) || fallback
           );
         }}
-        getHelperSlot={(f, fallback, slotKey) => {
+        getHelperSlot={(field: FormItemData, fallback, slotKey) => {
           return (
             generateSlotChildren(
               {
@@ -559,12 +560,12 @@ export const KubectlApplyForm = implementRuntimeComponent({
               },
               {
                 generateId(child) {
-                  return f.index !== undefined
-                    ? `${child.id}_${f.index}`
+                  return field.index !== undefined
+                    ? `${child.id}_${field.index}`
                     : child.id;
                 },
                 generateProps() {
-                  return (f as Static<typeof UiConfigFieldSpec>) || {};
+                  return (field as Static<typeof UiConfigFieldSpec>) || {};
                 },
               }
             ) || fallback


### PR DESCRIPTION
新增支持 KAF 表单项对布局的配置。

## Spec
Prop Spec 中新增 `type`，可用于选择配置字段还是布局，选择后会有对应不同的配置项，布局的配置项如下图所示：
<img width="308" alt="image" src="https://user-images.githubusercontent.com/25414733/209489319-69cedbd1-5b6d-418e-a3e7-c7b28b1269b6.png">

`layoutWidget` 用于选择哪种方式进行布局，现在可选的值有 `default`，`group`, `card`。`default` 没有任何的样式效果，仅仅将所有布局中的子字段看做为一组，可以一起进行缩进。

`card` 和 `group` 与字段配置中的样式一致，并提供 `widgetOptions` 进行进一步配置，效果预览：

<img width="523" alt="image" src="https://user-images.githubusercontent.com/25414733/209490605-0b0da00b-5912-4cd7-ac7c-68cee925040b.png">

<img width="518" alt="image" src="https://user-images.githubusercontent.com/25414733/209490642-3ecb573e-206a-45d1-9796-9a24a163f580.png">

## Summary List
用于新增布局配置，所以 Summary List 的规则也要适配一下，等 https://github.com/Yuyz0112/kui/pull/88 合入后进行修改。

## 其他
在 Widget 引入 Group 的时候，出现一个循环引用的问题，排查后是 `getFields` 生成字段信息时也会使用到表单项组件，但好像没有实际作用，因此将这些逻辑去除以解决问题。


