### PR TITLE
feat(KAF): allow use custom kind to create the empty custom schema

### DIFF
--- a/src/_internal/organisms/KubectlApplyForm/KubectlApplyForm.tsx
+++ b/src/_internal/organisms/KubectlApplyForm/KubectlApplyForm.tsx
@@ -45,6 +45,8 @@ import {
 import { transformFields } from "./utils";
 import mitt from "mitt";
 
+export const CUSTOM_SCHEMA_KIND = "x-dovetail-custom-kind";
+
 export type KubectlApplyFormProps = {
   className?: string;
   basePath: string;

--- a/src/editor/widgets/k8s/remote-schema.ts
+++ b/src/editor/widgets/k8s/remote-schema.ts
@@ -190,7 +190,7 @@ class K8sOpenAPI {
     }
 
     const properties = this.cache.openApi.definitions[def].properties;
-    let spec = key ? properties[key] : properties;
+    const spec = key ? properties[key] : properties;
 
     this.resolveRef(spec, {
       prune: {
@@ -210,9 +210,13 @@ class K8sOpenAPI {
     kind: string
   ): Promise<JSONSchema7 | null> {
     if (!this.cache.openApi.swagger) {
-      this.cache.openApi = await ky
-        .get(`${this.options.basePath}/openapi/v2`)
-        .json<any>();
+      try {
+        this.cache.openApi = await ky
+          .get(`${this.options.basePath}/openapi/v2`)
+          .json<any>();
+      } catch {
+        return null;
+      }
     }
 
     let schema;
@@ -253,6 +257,7 @@ class K8sOpenAPI {
         xProperty: true,
       },
     });
+
     return schema;
   }
 }

--- a/src/editor/widgets/k8s/store.ts
+++ b/src/editor/widgets/k8s/store.ts
@@ -11,7 +11,7 @@ import K8sOpenAPI, { k8sOpenAPIMap } from "./remote-schema";
 
 export class WidgetStore {
   resources = [];
-  schemas: JSONSchema7[] = [];
+  schemas: (JSONSchema7 | null)[] = [];
 
   constructor() {
     makeObservable(this, {
@@ -31,24 +31,22 @@ export class WidgetStore {
   }
 
   async fetchResourcesSchemas(basePath: string, resources: any[]) {
-    const schemas = (
-      await Promise.all(
-        resources.map(async (resource) => {
-          const { apiVersionWithGroup, kind } = resource;
-          const api = k8sOpenAPIMap[basePath] || new K8sOpenAPI({basePath});
+    const schemas = await Promise.all(
+      resources.map(async (resource) => {
+        const { apiVersionWithGroup, kind } = resource;
+        const api = k8sOpenAPIMap[basePath] || new K8sOpenAPI({ basePath });
 
-          k8sOpenAPIMap[basePath] = api;
+        k8sOpenAPIMap[basePath] = api;
 
-          if (apiVersionWithGroup && kind) {
-            const schema = await api.getResourceSchema(apiVersionWithGroup, kind);
+        if (apiVersionWithGroup && kind) {
+          const schema = await api.getResourceSchema(apiVersionWithGroup, kind);
 
-            return schema;
-          }
+          return schema;
+        }
 
-          return null;
-        })
-      )
-    ).filter((schema): schema is JSONSchema7 => schema !== null);
+        return null;
+      })
+    );
 
     runInAction(() => {
       this.schemas = schemas;

--- a/src/sunmao/components/KubectlApplyForm.tsx
+++ b/src/sunmao/components/KubectlApplyForm.tsx
@@ -7,7 +7,9 @@ import merge from "lodash/merge";
 import set from "lodash/set";
 import cloneDeep from "lodash/cloneDeep";
 import isEqual from "lodash/isEqual";
-import _KubectlApplyForm from "../../_internal/organisms/KubectlApplyForm/KubectlApplyForm";
+import _KubectlApplyForm, {
+  CUSTOM_SCHEMA_KIND,
+} from "../../_internal/organisms/KubectlApplyForm/KubectlApplyForm";
 import { css } from "@emotion/css";
 import {
   FORM_WIDGETS_MAP,
@@ -371,10 +373,14 @@ export const KubectlApplyForm = implementRuntimeComponent({
             const sdk = new KubeSdk({
               basePath,
             });
+            const appliedValues = values.filter(
+              (value, index) => !formConfig.schemas[index][CUSTOM_SCHEMA_KIND]
+            );
+
             mergeState({
               loading: true,
             });
-            sdk.applyYaml(values).catch((error: { response: Response }) => {
+            sdk.applyYaml(appliedValues).catch((error: { response: Response }) => {
               if (error.response) {
                 error.response
                   .clone()


### PR DESCRIPTION
支持使用自定义的 Schema，以解决当 K8S 资源的 Schema 难以配置对应的 UI 表单时的问题。

## 方案
之前当没有能获取到对应资源的 Schema 时，进入第二步会显示空白错误，现在修改为会生成一个空白的 Schema 并附带 `x-dovetail-custom-kind` 来标明这是一个自定义 Schema ，用户可对其进行编辑修改为自己需要的 Schema，该 Schema 不会被 apply 进行单独提交，之后会有新的提交来提供转换数据融合到 k8s 资源值中进行统一 apply。

## 使用
在 KAF 配置第一步中随意声明一个 Kind，只要不能成功通过 OpenAPI 来获取到其 Schema 即可：
<img width="216" alt="image" src="https://user-images.githubusercontent.com/25414733/209492617-a874ae91-26a7-4642-8adb-406f237976e9.png">

然后点击下一步，就会自动生成一个空白的 Schema，可以对它进行正常编辑：
<img width="357" alt="image" src="https://user-images.githubusercontent.com/25414733/209492786-1ed10c8f-5a43-48c2-8e10-3bd6565f4445.png">
