### PR TITLE
types: fix types errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "dev": "vite",
-    "prepublish": "npm run build",
+    "prepublish": "npm run build && npm run typings",
     "build": "vite build",
     "postbuild": "sed -i -e 's/\"useInsertionEffect\"/\"useInsertion\"+\"Effect\"/g' ./dist/index.js",
     "typings": "tsc --emitDeclarationOnly",
@@ -78,7 +78,6 @@
     "sass": "^1.51.0",
     "typescript": "^4.6.3",
     "vite": "^3.2.5",
-    "vite-plugin-dts": "2.0.0-beta.3",
     "vite-plugin-imp": "^2.2.0",
     "vite-plugin-monaco-editor": "^1.1.0",
     "vite-tsconfig-paths": "^3.4.1"

--- a/src/editor/widgets/type.d.ts
+++ b/src/editor/widgets/type.d.ts
@@ -13,19 +13,19 @@ declare module "@sunmao-ui/editor-sdk" {
     "kui/v1/PathWidget": {
       paths: string[];
     };
-    "kui/v1/ApiBaseWidget": {};
-    "kui/v1/KindWidget": {};
-    "kui/v1/ResourceWidget": {};
+    "kui/v1/ApiBaseWidget": Record<string, unknown>;
+    "kui/v1/KindWidget": Record<string, unknown>;
+    "kui/v1/ResourceWidget": Record<string, unknown>;
     "kui/v1/OptionsWidget": {
       optionsMap: Record<string, JSONSchema7>;
     };
-    "kui/v1/KubectlApplyFormDesignWidget": {};
+    "kui/v1/KubectlApplyFormDesignWidget": Record<string, unknown>;
     "kui/v1/KubectlApplyFormFieldWidget": {
       parentPath: string;
     };
-    "kui/v1/KubectlGetDetailLayoutWidget": {};
-    "kui/v1/KubectlGetDetailFieldWidget": {};
-    "kui/v1/KubectlGetTableColumnWidget": {};
+    "kui/v1/KubectlGetDetailLayoutWidget": Record<string, unknown>;
+    "kui/v1/KubectlGetDetailFieldWidget": Record<string, unknown>;
+    "kui/v1/KubectlGetTableColumnWidget": Record<string, unknown>;
   }
 }
 

--- a/src/sunmao/components/KubectlGetTable.tsx
+++ b/src/sunmao/components/KubectlGetTable.tsx
@@ -602,7 +602,7 @@ export const KubectlGetTable = implementRuntimeComponent({
                   record,
                   index,
                 },
-                (slotProps: any, fallback: any, slotKey: string) =>
+                (slotProps: any, fallback: any, slotKey?: string) =>
                   generateSlotChildren(
                     {
                       app,
@@ -611,7 +611,7 @@ export const KubectlGetTable = implementRuntimeComponent({
                       allComponents,
                       slotsElements,
                       slot: "cell",
-                      slotKey,
+                      slotKey: slotKey || "",
                       fallback,
                     },
                     {

--- a/src/sunmao/utils/widget.tsx
+++ b/src/sunmao/utils/widget.tsx
@@ -1,6 +1,7 @@
 import { DISPLAY_WIDGETS_MAP } from "../../_internal/molecules/display";
 import ObjectAge from "../../_internal/molecules/ObjectAge";
 import ObjectLabel from "../../_internal/molecules/ObjectLabel";
+import React from "react";
 
 export type Field = {
   path: string;
@@ -16,12 +17,18 @@ export type Field = {
 export function renderWidget(
   field: Field,
   data: { value: any; renderedValue?: any; [props: string]: any },
-  slot?: Function,
+  slot?: (
+    props: any,
+    fallback?: React.ReactNode,
+    key?: string | undefined
+  ) => React.ReactNode,
   slotKey?: string
 ) {
   const { value, record, renderedValue } = data;
   const { widget, widgetOptions = {}, transform, ...restField } = field;
-  const transformedValue = transform ? transform(restField, data) : (renderedValue ?? value);
+  const transformedValue = transform
+    ? transform(restField, data)
+    : renderedValue ?? value;
   let node = transformedValue;
 
   if (widget && widget !== "default") {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "declaration": true,
-    "declarationDir": "lib"
+    "outDir": "dist",
+    "declarationDir": "dist"
   },
   "include": ["src"],
   "exclude": ["node_modules"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,6 @@ import sunmaoFsVitePlugin from "./tools/sunmao-fs-vite-plugin";
 import linariaVitePlugin from "./tools/linaria-vite-plugin";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { getProxyConfig, applyK8sYamlPlugin } from "./tools/proxy-k8s";
-import dts from "vite-plugin-dts";
 import monacoEditorPlugin from "vite-plugin-monaco-editor";
 
 const globalSassPath = path.resolve(
@@ -53,10 +52,6 @@ export default defineConfig({
   },
   plugins: [
     tsconfigPaths(),
-    dts({
-      insertTypesEntry: true,
-      tsConfigFilePath: path.resolve(__dirname, './tsconfig.json'),
-    }),
     sunmaoFsVitePlugin({
       schemas: [
         {


### PR DESCRIPTION
通过 `vite-plugin-dts` 来构建类型会一直报 Sunmao 相关的类型错误（比如 Editor Widget 的类型不正确），暂时没有找到解决方案，先改回使用 `tsc` 来构建类型定义文件。