### PR TITLE
fix: change table and form

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-ui/ui",
-  "version": "0.3.33",
+  "version": "0.3.34",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-ui/ui",
-  "version": "0.3.34",
+  "version": "0.3.36",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-ui/ui",
-  "version": "0.3.32",
+  "version": "0.3.33",
   "files": [
     "dist"
   ],

--- a/src/_internal/k8s-api-client/kube-api.ts
+++ b/src/_internal/k8s-api-client/kube-api.ts
@@ -57,6 +57,7 @@ type KubeApiListOptions = {
 
 type KubeApiListWatchOptions<T> = KubeApiListOptions & {
   onResponse?: (response: T) => void;
+  onWatchUpdate?: (response: T) => void;
 };
 
 type KubeApiLinkRef = {
@@ -209,6 +210,7 @@ export class KubeApi<T extends UnstructuredList> {
     namespace,
     query,
     onResponse,
+    onWatchUpdate,
   }: KubeApiListWatchOptions<T> = {}): Promise<StopWatchHandler> {
     const url = this.getUrl({ namespace });
     const watchUrl = this.watchWsBasePath
@@ -222,7 +224,7 @@ export class KubeApi<T extends UnstructuredList> {
     const stop = this.watch(
       watchUrl,
       response,
-      onResponse,
+      onWatchUpdate,
       this.listWatch.bind(this, {
         namespace,
         query,
@@ -238,7 +240,7 @@ export class KubeApi<T extends UnstructuredList> {
   private async watch(
     url: string,
     response: T,
-    onResponse: KubeApiListWatchOptions<T>["onResponse"],
+    onWatchUpdate: KubeApiListWatchOptions<T>["onResponse"],
     // let listwatch know it needs retry
     retry: () => Promise<StopWatchHandler>
   ): Promise<StopWatchHandler> {
@@ -295,7 +297,7 @@ export class KubeApi<T extends UnstructuredList> {
           break;
         default:
       }
-      onResponse?.({
+      onWatchUpdate?.({
         ...response,
         items,
       });

--- a/src/_internal/molecules/ArrayCards.tsx
+++ b/src/_internal/molecules/ArrayCards.tsx
@@ -12,6 +12,9 @@ import { JSONSchema7 } from "json-schema";
 import { useTranslation } from "react-i18next";
 import { cloneDeep, set } from "lodash";
 
+const CardStyle = css`
+  margin-bottom: 16px;
+`;
 const AddedButtonStyle = css``;
 
 export const OptionsSpec = Type.Object({
@@ -104,6 +107,7 @@ const ArrayCards = (props: Props) => {
         return (
           <Card
             {...props}
+            className={CardStyle}
             key={itemIndex}
             value={itemValue}
             spec={itemSpec as JSONSchema7}

--- a/src/_internal/molecules/ArrayGroups.tsx
+++ b/src/_internal/molecules/ArrayGroups.tsx
@@ -14,8 +14,13 @@ import { cloneDeep } from "lodash";
 import registry from "../../services/Registry";
 import { StringUnion } from "@sunmao-ui/runtime";
 import { set } from "lodash";
-import { COMMON_ARRAY_OPTIONS } from './ArrayItems';
+import { COMMON_ARRAY_OPTIONS } from "./ArrayItems";
 
+const GroupStyle = css`
+  &.dovetail-ant-collapse {
+    margin-bottom: 16px;
+  }
+`;
 const AddedButtonStyle = css``;
 
 export const OptionsSpec = Type.Object({
@@ -108,6 +113,7 @@ const ArrayGroups = (props: Props) => {
         return (
           <Group
             {...props}
+            className={GroupStyle}
             key={itemIndex}
             value={itemValue}
             spec={itemSpec as JSONSchema7}

--- a/src/_internal/molecules/AutoForm/SpecField/FormEditor.tsx
+++ b/src/_internal/molecules/AutoForm/SpecField/FormEditor.tsx
@@ -89,7 +89,7 @@ const FormEditor = React.forwardRef<FormEditorHandle, FormEditorProps>(function 
     }
 
     setEditorErrors(errorMsgs);
-  }, [t]);
+  }, [t, field?.editorFormatError, field?.editorSchemaError]);
   const emitChange = useCallback(() => {
     if (!editorErrors.length) {
       const result = yaml.load(editorRef.current?.getEditorValue() || "") as Record<string, unknown>;
@@ -132,9 +132,8 @@ const FormEditor = React.forwardRef<FormEditorHandle, FormEditorProps>(function 
         setErrors(errorMsgs);
       });
     }
-    // only trigger validate when value of field changed
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fieldOrItem, value]);
+  }, [fieldOrItem, value, editorErrors.length]);
 
   return (
     <YamlEditorComponent

--- a/src/_internal/molecules/AutoForm/SpecField/FormItem.tsx
+++ b/src/_internal/molecules/AutoForm/SpecField/FormItem.tsx
@@ -67,6 +67,7 @@ const FormItemStyle = css`
       white-space: pre-wrap;
   
       label:after {
+        display: none;
         content: "";
         margin: 0;
       }
@@ -195,7 +196,7 @@ const FormItem = React.forwardRef<HTMLDivElement, TemplateProps>(
           displayLabel ? (
             <span
               style={{ width: labelWidth || `${108}px` }}
-              className={cx(Typo.Label.l3_regular_title, FormItemLabelStyle)}
+              className={cx(Typo.Label.l3_regular_title, FormItemLabelStyle, "form-item-label")}
             >
               {label}
             </span>

--- a/src/_internal/molecules/AutoForm/SpecField/SectionTitle.tsx
+++ b/src/_internal/molecules/AutoForm/SpecField/SectionTitle.tsx
@@ -1,0 +1,76 @@
+import React, { useContext } from "react";
+import { css, cx } from "@linaria/core";
+import { KitContext } from "../../../atoms/kit-context";
+import { useTranslation } from "react-i18next";
+import { Typo } from "../../../atoms/themes/CloudTower/styles/typo.style";
+
+export const FieldSection = css`
+    padding: 7px 0;
+    line-height: 18px;
+    border-bottom: 1px solid rgba(211, 218, 235, 0.6);
+    margin-bottom: 16px;
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+  
+    .section-title-text {
+      font-weight: 700;
+      color: rgba(44, 56, 82, 0.60);
+    }
+
+    &.editor-switch-section-title {
+      .section-title-text {
+        font-weight: 400;
+      }
+    }
+`;
+
+const EditYAMLTextStyle = css`
+  color: rgba(44, 56, 82, 0.60);
+  margin-right: 16px;
+`;
+
+type SectionTitleProps = {
+  isDisplayEditorSwitch: boolean;
+  sectionTitle?: string;
+  editorSwitchTooltip?: string;
+  isEnableEditor?: boolean;
+  isDisabledSwitchEditor?: boolean;
+  onEnableEditorChange?: (checked: boolean) => void;
+}
+
+function SectionTitle(props: SectionTitleProps) {
+  const {
+    isDisplayEditorSwitch,
+    sectionTitle,
+    editorSwitchTooltip,
+    isEnableEditor,
+    isDisabledSwitchEditor,
+    onEnableEditorChange
+  } = props;
+  const { i18n } = useTranslation();
+  const kit = useContext(KitContext);
+
+  return (
+    <div className={cx(FieldSection, "field-section-title", isDisplayEditorSwitch ? "editor-switch-section-title" : null)}>
+      <span className={cx("section-title-text")}>{sectionTitle}</span>
+      {isDisplayEditorSwitch ? (
+        <span>
+          <span className={cx(Typo.Label.l4_regular, EditYAMLTextStyle)}>{i18n.t("dovetail.edit_yaml")}</span>
+          <kit.Tooltip title={editorSwitchTooltip}>
+            <span>
+              <kit.Switch
+                disabled={isDisabledSwitchEditor}
+                checked={isEnableEditor}
+                onChange={onEnableEditorChange}
+                size="small"
+              ></kit.Switch>
+            </span>
+          </kit.Tooltip>
+        </span>
+      ) : null}
+    </div>
+  )
+}
+
+export default SectionTitle;

--- a/src/_internal/molecules/AutoForm/SpecField/index.tsx
+++ b/src/_internal/molecules/AutoForm/SpecField/index.tsx
@@ -2,7 +2,6 @@ import React, { useState, useCallback, useContext, useRef } from "react";
 import isEmpty from "lodash/isEmpty";
 // TODO: use kit context when I have time:)
 import { Col } from "antd";
-import { css, cx } from "@linaria/core";
 import { JSONSchema7 } from "json-schema";
 import { WidgetProps } from "../widget";
 import UnsupportedField from "../UnsupportedField";
@@ -24,34 +23,7 @@ import { KitContext } from "../../../atoms/kit-context";
 import FormItem from "./FormItem";
 import FormEditor, { FormEditorHandle } from "./FormEditor";
 import { useTranslation } from "react-i18next";
-import { Typo } from "../../../atoms/themes/CloudTower/styles/typo.style";
-
-export const FieldSection = css`
-    padding-bottom: 6px;
-    border-bottom: 1px solid rgba(213, 219, 227, 0.6);
-    margin-bottom: 16px;
-    display: flex;
-    justify-content: space-between;
-    width: 100%;
-  
-    .title {
-      font-weight: 700;
-      color: #2d3a56;
-    }
-  `;
-
-const EditYAMLTextStyle = css`
-  color: rgba(44, 56, 82, 0.60);
-  margin-right: 16px;
-`;
-
-const SectionTitleStyle = css`
-  font-weight: 700;
-`;
-
-const SwitchEditorTitleStyle = css`
-  font-weight: 400;
-`;
+import SectionTitle from "./SectionTitle";
 
 function shouldDisplayDescription(spec: JSONSchema7): boolean {
   if (spec.type === "object") {
@@ -124,17 +96,17 @@ const SpecField: React.FC<SpecFieldProps> = (props) => {
   const fieldOrItem = transformedField || transformedItem;
   const label = transformedField?.label || title || "";
   let isDisplayLabel =
-  transformedField?.type === "layout"
-  ? transformedField.indent
-  : transformedField?.isDisplayLabel;
+    transformedField?.type === "layout"
+      ? transformedField.indent
+      : transformedField?.isDisplayLabel;
   const displayDescription = shouldDisplayDescription(spec);
   const itemKey = `${props.superiorKey
     ? `${props.superiorKey}${transformedField?.key ? "-" : ""}`
     : ""
-  }${transformedField?.key || ""}`;
+    }${transformedField?.key || ""}`;
   const finalError = error || fieldOrItem?.error;
-  const [isEnableEditor, setIsEnableEditor] = useState(enabledEditorMap[itemKey] ??  false);
-  
+  const [isEnableEditor, setIsEnableEditor] = useState(enabledEditorMap[itemKey] ?? false);
+
 
   const onEnableEditorChange = useCallback((enabled) => {
     if (!enabled) {
@@ -255,24 +227,14 @@ const SpecField: React.FC<SpecFieldProps> = (props) => {
       }}
     >
       {transformedField?.sectionTitle && (
-        <div className={FieldSection}>
-          <span className={cx("section-title-text", isDisplayEditorSwitch ? SwitchEditorTitleStyle : SectionTitleStyle)}>{transformedField?.sectionTitle}</span>
-          {isDisplayEditorSwitch ? (
-            <span>
-              <span className={cx(Typo.Label.l4_regular, EditYAMLTextStyle)}>{i18n.t("dovetail.edit_yaml")}</span>
-              <kit.Tooltip title={transformedField.editorSwitchTooltip}>
-                <span>
-                  <kit.Switch
-                    disabled={!!transformedField.isDisabledSwitchEditor}
-                    checked={isEnableEditor}
-                    onChange={onEnableEditorChange}
-                    size="small"
-                  ></kit.Switch>
-                </span>
-              </kit.Tooltip>
-            </span>
-          ) : null}
-        </div>
+        <SectionTitle
+          isDisplayEditorSwitch={!!isDisplayEditorSwitch}
+          sectionTitle={transformedField?.sectionTitle}
+          editorSwitchTooltip={transformedField.editorSwitchTooltip}
+          isDisabledSwitchEditor={!!transformedField.isDisabledSwitchEditor}
+          isEnableEditor={isEnableEditor}
+          onEnableEditorChange={onEnableEditorChange}
+        />
       )}
       {
         isEnableEditor ? (

--- a/src/_internal/molecules/Card.tsx
+++ b/src/_internal/molecules/Card.tsx
@@ -13,7 +13,6 @@ const CardWrapper = styled.div`
   background: rgba(237, 241, 250, 0.6);
   border: 1px solid rgba(211, 218, 235, 0.6);
   border-radius: 8px;
-  margin-bottom: 16px;
 `;
 const CardHeader = styled.div`
   display: flex;
@@ -40,15 +39,16 @@ export const OptionsSpec = Type.Object({
 });
 
 type Props = WidgetProps<any, Static<typeof OptionsSpec>> & {
+  className?: string;
   onRemove?: () => void;
 };
 
 const Card = (props: Props) => {
   const kit = useContext(KitContext);
-  const { widgetOptions, onRemove } = props;
+  const { widgetOptions, className, onRemove } = props;
 
   return (
-    <CardWrapper>
+    <CardWrapper className={className}>
       {widgetOptions?.title || onRemove ? (
         <CardHeader>
           <CardTitle className={Typo.Label.l2_regular}>

--- a/src/_internal/molecules/Editor.tsx
+++ b/src/_internal/molecules/Editor.tsx
@@ -6,6 +6,7 @@ import { YamlEditorComponent, Handle as EditorHandle } from "../../sunmao/compon
 import { Events } from "../organisms/KubectlApplyForm/type";
 import yaml from "js-yaml";
 import { isEqual } from "lodash";
+import SectionTitle from "../molecules/AutoForm/SpecField/SectionTitle";
 
 export const OptionsSpec = Type.Object({
   title: Type.String(),
@@ -13,6 +14,7 @@ export const OptionsSpec = Type.Object({
   isDefaultCollapsed: Type.Boolean(),
   formatError: Type.String(),
   schemaError: Type.String(),
+  sectionTitle: Type.String(),
 });
 
 export type EditorProps = WidgetProps<Record<string, unknown> | string, Static<typeof OptionsSpec>>;
@@ -23,7 +25,7 @@ function Editor(props: EditorProps) {
   const ref = useRef<EditorHandle>(null);
   const [editorErrors, setEditorErrors] = useState<string[]>([]);
   const [isShowErrors, setIsShowErrors] = useState<boolean>(false);
-  const schema = useMemo(()=> ["object", "array"].includes(spec.type as string) ? spec : undefined, [spec]);
+  const schema = useMemo(() => ["object", "array"].includes(spec.type as string) ? spec : undefined, [spec]);
   const defaultValue = useMemo(
     () => {
       if (field?.defaultValue === undefined) return "";
@@ -54,7 +56,7 @@ function Editor(props: EditorProps) {
     result[itemKey] = editorErrors;
     setIsShowErrors(!!editorErrors.length);
   }, [editorErrors, itemKey]);
-  const emitChange = useCallback(()=> {
+  const emitChange = useCallback(() => {
     if (!editorErrors.length) {
       const editorValue = ref.current?.getEditorValue() || "";
       const newValue = typeof value === "string" ? editorValue : yaml.load(editorValue) as Record<string, unknown>;
@@ -93,18 +95,26 @@ function Editor(props: EditorProps) {
     };
   }, [services.event, onValidateEvent]);
 
-  return (<YamlEditorComponent
-    ref={ref}
-    {...props.widgetOptions}
-    id={itemKey}
-    defaultValue={defaultValue}
-    schema={schema}
-    errorMsgs={isShowErrors ? editorErrors : []}
-    onValidate={onEditorValidate}
-    onEditorCreate={changeValue}
-    onChange={emitChange}
-    onBlur={emitChange}
-  />)
+  return (<>
+    {props.widgetOptions?.sectionTitle && <SectionTitle
+      sectionTitle={props.widgetOptions?.sectionTitle}
+      isDisplayEditorSwitch
+      isEnableEditor
+      isDisabledSwitchEditor
+    />}
+    <YamlEditorComponent
+      ref={ref}
+      {...props.widgetOptions}
+      id={itemKey}
+      defaultValue={defaultValue}
+      schema={schema}
+      errorMsgs={isShowErrors ? editorErrors : []}
+      onValidate={onEditorValidate}
+      onEditorCreate={changeValue}
+      onChange={emitChange}
+      onBlur={emitChange}
+    />
+  </>)
 }
 
 export default Editor;

--- a/src/_internal/molecules/Group.tsx
+++ b/src/_internal/molecules/Group.tsx
@@ -7,7 +7,7 @@ import { KitContext } from "../atoms/kit-context";
 import { CloseOutlined } from "@ant-design/icons";
 import { Row, Collapse } from "antd";
 import { Typo } from "../atoms/themes/CloudTower/styles/typo.style";
-import { css } from "@emotion/css";
+import { css, cx } from "@emotion/css";
 import Icon from "../atoms/themes/CloudTower/components/Icon/Icon";
 import registry from "../../services/Registry";
 import { StringUnion } from "@sunmao-ui/runtime";
@@ -19,7 +19,6 @@ const GroupWrapperStyle = css`
   &.dovetail-ant-collapse {
     border: 1px solid #e4e9f2;
     border-radius: 8px;
-    margin-bottom: 16px;
     background: transparent;
 
     & > .dovetail-ant-collapse-item.dovetail-ant-collapse-no-arrow > .dovetail-ant-collapse-header {
@@ -127,16 +126,19 @@ type GroupProps = WidgetProps<
   Record<string, any>,
   Static<typeof OptionsSpec>
 > & {
+  className?: string;
   onRemove?: () => void;
 };
 
 const Group = (props: GroupProps) => {
-  const { path, widgetOptions, onRemove } = props;
+  const { path, widgetOptions, className, onRemove } = props;
   const kit = useContext(KitContext);
   const icon = registry.icons.get(widgetOptions?.icon as any);
 
   return (
-    <Collapse className={GroupWrapperStyle} defaultActiveKey={["panel"]}>
+    <Collapse
+      className={cx(GroupWrapperStyle, className)}
+      defaultActiveKey={["panel"]}>
       <Panel
         key="panel"
         header={

--- a/src/_internal/organisms/KubectlGetDetail/KubectlGetDetail.tsx
+++ b/src/_internal/organisms/KubectlGetDetail/KubectlGetDetail.tsx
@@ -231,6 +231,19 @@ const KubectlGetDetail = React.forwardRef<
         namespace,
       },
     });
+    const onResponseAndWatchUpdate = (res: UnstructuredList) => {
+      setResponse(() => ({
+        loading: false,
+        error: null,
+        data: res.items[0]
+          ? {
+              ...res.items[0],
+              kind: res.kind.replace(/List$/g, ""),
+              apiVersion: res.apiVersion,
+            }
+          : null,
+      }));
+    };
 
     setResponse((prev) => ({ ...prev, loading: true }));
 
@@ -244,24 +257,13 @@ const KubectlGetDetail = React.forwardRef<
             )
           ),
         },
-        onResponse: (res) => {
-          setResponse(() => ({
-            loading: false,
-            error: null,
-            data: res.items[0]
-              ? {
-                  ...res.items[0],
-                  kind: res.kind.replace(/List$/g, ""),
-                  apiVersion: res.apiVersion,
-                }
-              : null,
-          }));
-        },
+        onResponse: onResponseAndWatchUpdate,
+        onWatchUpdate: onResponseAndWatchUpdate,
       })
       .catch((err) => {
         setResponse(() => ({ loading: false, error: err, data: null }));
       });
-  }, [basePath, watchWsBasePath, apiBase, namespace, resource, name]);
+  }, [basePath, watchWsBasePath, apiBase, namespace, resource, name, query]);
 
   useEffect(() => {
     onResponse?.(response);

--- a/src/_internal/organisms/KubectlGetList.tsx
+++ b/src/_internal/organisms/KubectlGetList.tsx
@@ -95,24 +95,27 @@ const KubectlGetList = React.forwardRef<HTMLElement, KubectlGetListProps>(
           namespace,
         },
       });
+      const onResponseAndWatchUpdate = (res: UnstructuredList) => {
+        setResponse(() => ({
+          loading: false,
+          error: null,
+          data: {
+            ...res,
+            items: res.items.sort(
+              (a, b) =>
+                new Date(b.metadata.creationTimestamp as string).getTime() -
+                new Date(a.metadata.creationTimestamp as string).getTime()
+            ),
+          },
+        }));
+      };
+
       setResponse((prev) => ({ ...prev, loading: true }));
       return api
         .listWatch({
           query: query || {},
-          onResponse: (res) => {
-            setResponse(() => ({
-              loading: false,
-              error: null,
-              data: {
-                ...res,
-                items: res.items.sort(
-                  (a, b) =>
-                    new Date(b.metadata.creationTimestamp as string).getTime() -
-                    new Date(a.metadata.creationTimestamp as string).getTime()
-                ),
-              },
-            }));
-          },
+          onResponse: onResponseAndWatchUpdate,
+          onWatchUpdate: onResponseAndWatchUpdate
         })
         .catch((err) => {
           setResponse(() => ({ loading: false, error: err, data: emptyData }));

--- a/src/_internal/organisms/UnstructuredPage.tsx
+++ b/src/_internal/organisms/UnstructuredPage.tsx
@@ -76,17 +76,19 @@ const UnstructuredPage = React.forwardRef<
         namespace,
       },
     });
+    const onResponseAndWatchUpdate = (res: UnstructuredList) => {
+      setResponse(() => ({
+        loading: false,
+        error: null,
+        data: res.items[0] || null,
+      }));
+    };
     setResponse((prev) => ({ ...prev, loading: true }));
     const stopP = api
       .listWatch({
         query: fieldSelector ? { fieldSelector } : {},
-        onResponse: (res) => {
-          setResponse(() => ({
-            loading: false,
-            error: null,
-            data: res.items[0] || null,
-          }));
-        },
+        onResponse: onResponseAndWatchUpdate,
+        onWatchUpdate: onResponseAndWatchUpdate
       })
       .catch((err) => {
         setResponse(() => ({ loading: false, error: err, data: null }));

--- a/src/sunmao/components/K8sNamespaceSelect.tsx
+++ b/src/sunmao/components/K8sNamespaceSelect.tsx
@@ -10,7 +10,7 @@ import React, {
   useState,
   useEffect,
 } from "react";
-import { KubeApi } from "../../_internal/k8s-api-client/kube-api";
+import { KubeApi, UnstructuredList } from "../../_internal/k8s-api-client/kube-api";
 
 export const K8sNamespaceSelect = implementRuntimeComponent({
   version: "kui/v1",
@@ -67,15 +67,17 @@ export const K8sNamespaceSelect = implementRuntimeComponent({
   );
 
   useEffect(() => {
+    const onResponseAndWatchUpdate = (value: UnstructuredList)=> {
+      setOptions(
+        value.items.map((namespace) => ({
+          label: namespace.metadata.name || "",
+          value: namespace.metadata.name || "",
+        }))
+      );
+    };
     api.listWatch({
-      onResponse(value) {
-        setOptions(
-          value.items.map((namespace) => ({
-            label: namespace.metadata.name || "",
-            value: namespace.metadata.name || "",
-          }))
-        );
-      },
+      onResponse: onResponseAndWatchUpdate,
+      onWatchUpdate: onResponseAndWatchUpdate,
     });
   }, [api]);
 

--- a/src/sunmao/components/KubectlGetTable.tsx
+++ b/src/sunmao/components/KubectlGetTable.tsx
@@ -22,7 +22,7 @@ import BaseKubectlGetTable, {
 import { renderWidget } from "../utils/widget";
 import { generateSlotChildren } from "../utils/slot";
 import { css, cx } from "@emotion/css";
-import { get } from "lodash";
+import { get, throttle } from "lodash";
 import { KitContext } from "../../_internal/atoms/kit-context";
 import semver from "semver";
 
@@ -299,6 +299,14 @@ const KubectlGetTableProps = Type.Object({
     category: PRESET_PROPERTY_CATEGORY.Behavior,
     title: "Enable row selection",
   }),
+  loading: Type.Boolean({
+    category: PRESET_PROPERTY_CATEGORY.Behavior,
+    title: "Loading"
+  }),
+  throttleWait: Type.Number({
+    category: PRESET_PROPERTY_CATEGORY.Behavior,
+    title: "Throttle wait"
+  }),
   scroll: Type.Object(
     {
       x: Type.String({ title: "X" }),
@@ -442,6 +450,8 @@ export const KubectlGetTable = implementRuntimeComponent({
     services,
     component,
     childrenMap,
+    throttleWait,
+    loading,
     mergeState,
     subscribeMethods,
   }) => {
@@ -543,9 +553,9 @@ export const KubectlGetTable = implementRuntimeComponent({
       },
       [callbackMap, mergeState]
     );
-    const onResponse = useCallback((response: Response) => {
+    const onResponse = throttle(useCallback((response: Response) => {
       setResponse(response);
-    }, []);
+    }, []), throttleWait || 0);
 
     useEffect(() => {
       subscribeMethods({
@@ -620,6 +630,86 @@ export const KubectlGetTable = implementRuntimeComponent({
       });
     }, []);
 
+    const finalColumns = useMemo(()=> columns.map((col, colIndex) => ({
+      ...col,
+      fixed: col.fixed === "none" ? undefined : col.fixed,
+      dataIndex: typeof col.dataIndex === "string"
+        ? col.dataIndex.split(".")
+        : col.dataIndex,
+      render: (value: any, record: any, index: number) => {
+        return renderWidget(
+          { ...col, path: col.dataIndex },
+          {
+            value: value,
+            renderedValue: value ?? "-",
+            record,
+            index,
+          },
+          (slotProps: any, fallback: any, slotKey?: string) => generateSlotChildren(
+            {
+              app,
+              services,
+              component,
+              allComponents,
+              slotsElements,
+              slot: "cell",
+              slotKey: slotKey || "",
+              fallback,
+              childrenMap,
+            },
+            {
+              generateId: (child) => {
+                return `${child.id}_${index}`;
+              },
+              generateProps() {
+                return slotProps;
+              },
+            }
+          ),
+          `column_${colIndex}_${index}`
+        );
+      },
+      sortOrder: columnSortOrder[col.key],
+      sortDirections: col.sortType === "none" ? null : ["", "ascend", "descend"],
+      sorter: col.sortType === "none"
+        ? undefined
+        : col.sortType === "server"
+          ? true
+          : (
+            a: UnstructuredList["items"][0],
+            b: UnstructuredList["items"][0]
+          ) => {
+            const valueA = get(a, col.sortBy || col.dataIndex);
+            const valueB = get(b, col.sortBy || col.dataIndex);
+
+            if (typeof valueA === "number" &&
+              typeof valueB === "number") {
+              return valueA - valueB;
+            } else if (semver.valid(valueA) && semver.valid(valueB)) {
+              return valueA === valueB ? 0 : (semver.lt(valueA, valueB) ? -1 : 1);
+            }
+
+            return String(valueA).localeCompare(String(valueB));
+          },
+      filters: col.filters?.length ? col.filters : undefined,
+      onFilter(value: string, record: UnstructuredList["items"][0]) {
+        const compare = col.filters.find(
+          (filter) => filter.value === value
+        )?.compare;
+        const cellValue = get(record, col.dataIndex);
+
+        switch (compare) {
+          case "equal": {
+            return cellValue === value;
+          }
+          case "includes": {
+            return cellValue.includes(value);
+          }
+        }
+
+        return true;
+      },
+    })), [allComponents, app, childrenMap, columnSortOrder, columns, component, services, slotsElements]);
     return (
       <div
         ref={elementRef}
@@ -639,92 +729,7 @@ export const KubectlGetTable = implementRuntimeComponent({
           namespace={namespace}
           apiBase={apiBase}
           query={query}
-          columns={columns.map((col, colIndex) => ({
-            ...col,
-            fixed: col.fixed === "none" ? undefined : col.fixed,
-            dataIndex:
-              typeof col.dataIndex === "string"
-                ? col.dataIndex.split(".")
-                : col.dataIndex,
-            render: (value: any, record: any, index: number) => {
-              return renderWidget(
-                { ...col, path: col.dataIndex },
-                {
-                  value: value,
-                  renderedValue: value ?? "-",
-                  record,
-                  index,
-                },
-                (slotProps: any, fallback: any, slotKey?: string) =>
-                  generateSlotChildren(
-                    {
-                      app,
-                      services,
-                      component,
-                      allComponents,
-                      slotsElements,
-                      slot: "cell",
-                      slotKey: slotKey || "",
-                      fallback,
-                      childrenMap,
-                    },
-                    {
-                      generateId: (child) => {
-                        return `${child.id}_${index}`;
-                      },
-                      generateProps() {
-                        return slotProps;
-                      },
-                    }
-                  ),
-                `column_${colIndex}_${index}`
-              );
-            },
-            sortOrder: columnSortOrder[col.key],
-            sortDirections:
-              col.sortType === "none" ? null : ["", "ascend", "descend"],
-            sorter:
-              col.sortType === "none"
-                ? undefined
-                : col.sortType === "server"
-                  ? true
-                  : (
-                    a: UnstructuredList["items"][0],
-                    b: UnstructuredList["items"][0]
-                  ) => {
-                    const valueA = get(a, col.sortBy || col.dataIndex);
-                    const valueB = get(b, col.sortBy || col.dataIndex);
-
-                    if (
-                      typeof valueA === "number" &&
-                      typeof valueB === "number"
-                    ) {
-                      return valueA - valueB;
-                    } else if (semver.valid(valueA) && semver.valid(valueB)) {
-                      return valueA === valueB ? 0 : (semver.lt(valueA, valueB) ? -1 : 1);
-                    }
-
-                    return String(valueA).localeCompare(String(valueB));
-                  },
-            filters: col.filters?.length ? col.filters : undefined,
-            onFilter(value: string, record: UnstructuredList["items"][0]) {
-              const compare = col.filters.find(
-                (filter) => filter.value === value
-              )?.compare;
-              const cellValue = get(record, col.dataIndex);
-
-              switch (compare) {
-                case "equal": {
-                  return cellValue === value;
-                }
-                case "includes": {
-                  return cellValue.includes(value);
-                }
-              }
-
-              return true;
-            },
-          }))}
+          columns={finalColumns}
           customizable={customizable}
           customizableKey={customizableKey}
           activeKey={activeKey}
@@ -736,6 +741,7 @@ export const KubectlGetTable = implementRuntimeComponent({
           resizable={resizable}
           selectedKeys={selectedKeys}
           wrapper={elementRef!}
+          loading={loading}
           onResponse={onResponse}
           onSelect={enableRowSelection ? onSelectChange : undefined}
           onActive={onActive}

--- a/src/sunmao/components/KubectlGetTable.tsx
+++ b/src/sunmao/components/KubectlGetTable.tsx
@@ -553,9 +553,9 @@ export const KubectlGetTable = implementRuntimeComponent({
       },
       [callbackMap, mergeState]
     );
-    const onResponse = throttle(useCallback((response: Response) => {
+    const onWatchUpdate = useCallback(throttle((response: Response) => {
       setResponse(response);
-    }, []), throttleWait || 0);
+    }, throttleWait || 0), [throttleWait]);
 
     useEffect(() => {
       subscribeMethods({
@@ -742,7 +742,10 @@ export const KubectlGetTable = implementRuntimeComponent({
           selectedKeys={selectedKeys}
           wrapper={elementRef!}
           loading={loading}
-          onResponse={onResponse}
+          onResponse={setResponse}
+          onWatchUpdate={onWatchUpdate}
+          onError={setResponse}
+          onFetchStart={setResponse}
           onSelect={enableRowSelection ? onSelectChange : undefined}
           onActive={onActive}
           onSorterChange={onSorterChange}

--- a/src/sunmao/components/YamlEditor/MonacoYamlEditor.tsx
+++ b/src/sunmao/components/YamlEditor/MonacoYamlEditor.tsx
@@ -5,6 +5,7 @@ import * as monaco from "monaco-editor";
 import { setDiagnosticsOptions } from "monaco-yaml";
 import React, { useEffect, useRef } from "react";
 import YamlWorker from "./yaml.worker?worker";
+import { YamlEditorStyle } from "./style";
 
 const uri = monaco.Uri.parse("monaco-yaml.yaml");
 
@@ -175,6 +176,7 @@ const MonacoYamlEditor: React.FC<Props> = props => {
   return (
     <div
       ref={ref}
+      className={YamlEditorStyle}
       style={{
         width: "100%",
         height: height || "500px",

--- a/src/sunmao/components/YamlEditor/YamlEditorComponent.tsx
+++ b/src/sunmao/components/YamlEditor/YamlEditorComponent.tsx
@@ -154,7 +154,7 @@ export const YamlEditorComponent = forwardRef<Handle, Props>(function YamlEditor
               iconHeight={16}
               onClick={() => setIsCollapsed(!isCollapsed)}
             />
-            <div className={TitleStyle}>{title || t("dovetail.configure_file")}</div>
+            <div className={cx(TitleStyle, "yaml-editor-title")}>{title || t("dovetail.configure_file")}</div>
           </kit.Space>
           <kit.Space size={14}>
             {isDiff ? undefined : (

--- a/src/sunmao/components/YamlEditor/style.ts
+++ b/src/sunmao/components/YamlEditor/style.ts
@@ -91,3 +91,18 @@ export const ErrorMsgStyle = css`
 export const ErrorWrapperStyle = css`
   margin-top: 8px;
 `;
+
+export const YamlEditorStyle = css`
+  .monaco-editor {
+    border-bottom-left-radius: 8px;
+    border-bottom-right-radius: 8px;
+
+    .margin {
+      border-bottom-left-radius: 8px;
+    }
+
+    .monaco-scrollable-element {
+      border-bottom-right-radius: 8px;
+    }
+  }
+`;


### PR DESCRIPTION
1. 优化表格性能
  - 使用 `useCallback` 和 `useMemo` 来避免不必要的重新渲染。原本表格更新时所有单元格都会重新渲染，现在只有特定变化的单元格会重新渲染
  - 支持设置节流来避免频繁设置表格数据
  - 将原本的 `onResponse` 拆分成 `onWatchUpdate`、`onFetchStart`、`onResponse`、`onError` 多个事件，方便单独处理每种情况 (commit: 764c6fc2391fee43d96eac0cd86f9e331d002da8)
2. 修改表格样式
3. 当编辑器格式校验通过后触发字段校验