### PR TITLE
fix kube api and editor issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-ui/ui",
-  "version": "0.3.36",
+  "version": "0.3.37",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-ui/ui",
-  "version": "0.3.37",
+  "version": "0.3.38",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-ui/ui",
-  "version": "0.3.38",
+  "version": "0.3.39",
   "files": [
     "dist"
   ],

--- a/src/_internal/k8s-api-client/kube-api.ts
+++ b/src/_internal/k8s-api-client/kube-api.ts
@@ -229,6 +229,7 @@ export class KubeApi<T extends UnstructuredList> {
         namespace,
         query,
         onResponse,
+        onWatchUpdate,
       })
     );
 

--- a/src/_internal/molecules/AutoForm/SpecField/useValidate.ts
+++ b/src/_internal/molecules/AutoForm/SpecField/useValidate.ts
@@ -100,9 +100,9 @@ export default function useValidate(props: UseValidateProps) {
 
       if (shouldValidateValue) {
         validate((messages: string[]) => {
-          result[itemKey] = error
+          result[itemKey] = (result[itemKey] || []).concat(error
             ? messages.concat(error, widgetErrors)
-            : messages;
+            : messages);
         });
       }
     },

--- a/src/sunmao/components/FullscreenModal.tsx
+++ b/src/sunmao/components/FullscreenModal.tsx
@@ -142,7 +142,7 @@ export const Modal = implementRuntimeComponent({
       mergeState({
         visible: false,
       });
-      callbackMap?.onClose();
+      callbackMap?.onClose?.();
     }, [callbackMap?.onClose]);
 
     return (


### PR DESCRIPTION
1. 修复 watch 断开后重新监听没有更新数据的问题
2. 修复没有给 Modal 传 onClose 的报错
3. 编辑器会在修复错误后再触发下值的提交
4. 在同一次校验中，不同地方对同一个字段的校验信息设置应该是合并而不是替换