### PR TITLE
remove the last-applied-configuration annotations and add disabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-ui/ui",
-  "version": "0.3.39",
+  "version": "0.3.40",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-ui/ui",
-  "version": "0.3.40",
+  "version": "0.3.41",
   "files": [
     "dist"
   ],

--- a/src/_internal/k8s-api-client/kube-api.ts
+++ b/src/_internal/k8s-api-client/kube-api.ts
@@ -555,12 +555,6 @@ export class KubeSdk {
 
       spec.metadata = spec.metadata || {};
       spec.metadata.annotations = spec.metadata.annotations || {};
-      delete spec.metadata.annotations[
-        "kubectl.kubernetes.io/last-applied-configuration"
-      ];
-      spec.metadata.annotations[
-        "kubectl.kubernetes.io/last-applied-configuration"
-      ] = JSON.stringify(spec);
 
       if (strategy === "application/apply-patch+yaml") {
         delete spec.metadata.managedFields;
@@ -594,9 +588,7 @@ export class KubeSdk {
         }
         changed.push(response as Unstructured);
       } catch (error) {
-        delete spec.metadata.annotations[
-          "kubectl.kubernetes.io/last-applied-configuration"
-        ];
+
         throw error;
       }
     }

--- a/src/_internal/molecules/ArrayItems.tsx
+++ b/src/_internal/molecules/ArrayItems.tsx
@@ -49,8 +49,11 @@ export const COMMON_ARRAY_OPTIONS = {
     })
   ),
   useFirstAsDefaultValue: Type.Optional(Type.Boolean({
-    title: 'Use first as default value',
-    description: 'Is use the value of first item as the default value when adding the new item?'
+    title: "Use first as default value",
+    description: "Is use the value of first item as the default value when adding the new item?"
+  })),
+  disabled: Type.Optional(Type.Boolean({
+    title: "Disabled"
   }))
 }
 
@@ -148,7 +151,10 @@ const ArrayItems = (props: Props) => {
               }}
               path={path.concat(`.${itemIndex}`)}
               level={level + 1}
-              widgetOptions={field?.subItem?.widgetOptions || {}}
+              widgetOptions={
+                { disabled: widgetOptions?.disabled, ...(field?.subItem?.widgetOptions || {}) } || 
+                { disabled: widgetOptions?.disabled }
+              }
               onChange={(
                 newItemValue: any,
                 newDisplayValues: Record<string, any>,
@@ -161,7 +167,7 @@ const ArrayItems = (props: Props) => {
               }}
             />
           </div>
-          {value.length > (widgetOptions?.minLength || 0) ? (
+          {value.length > (widgetOptions?.minLength || 0) && !widgetOptions.disabled ? (
             <kit.Button
               className={CloseButtonStyle}
               size="small"
@@ -178,8 +184,8 @@ const ArrayItems = (props: Props) => {
       {widgetOptions.helper && value.length ? (
         <HelperText>{widgetOptions.helper}</HelperText>
       ) : null}
-      {widgetOptions.addable !== false &&
-      value.length < (widgetOptions.maxLength || Number.MAX_SAFE_INTEGER) ? (
+      {widgetOptions.addable !== false && !widgetOptions?.disabled &&
+        value.length < (widgetOptions.maxLength || Number.MAX_SAFE_INTEGER) ? (
         <div style={{ marginTop: widgetOptions.helper ? 0 : "16px" }}>
           {widgetOptions.addedButtonIcon ? (
             <Icon type={widgetOptions.addedButtonIcon as IconTypes}></Icon>

--- a/src/_internal/molecules/Editor.tsx
+++ b/src/_internal/molecules/Editor.tsx
@@ -15,6 +15,7 @@ export const OptionsSpec = Type.Object({
   formatError: Type.String(),
   schemaError: Type.String(),
   sectionTitle: Type.String(),
+  readOnly: Type.Boolean(),
 });
 
 export type EditorProps = WidgetProps<Record<string, unknown> | string, Static<typeof OptionsSpec>>;

--- a/src/sunmao/components/YamlEditor/MonacoYamlEditor.tsx
+++ b/src/sunmao/components/YamlEditor/MonacoYamlEditor.tsx
@@ -20,6 +20,7 @@ type Props = {
   onBlur?: () => void;
   getInstance: (ins: monaco.editor.IStandaloneCodeEditor) => void;
   schema?: JSONSchema4;
+  readOnly?: boolean;
 };
 
 if (!import.meta.env.PROD) {
@@ -41,7 +42,7 @@ const schemaMap = new Map();
 const MonacoYamlEditor: React.FC<Props> = props => {
   const ref = useRef<HTMLDivElement>(null);
   const instanceRef = useRef<{ editor: monaco.editor.IStandaloneCodeEditor | null }>({ editor: null });
-  const { defaultValue, id, height, onChange, onValidate, getInstance, onEditorCreate, onBlur, schema } = props;
+  const { defaultValue, id, height, readOnly, onChange, onValidate, getInstance, onEditorCreate, onBlur, schema } = props;
   const uri = id ? monaco.Uri.parse(`${id}.yaml`) : undefined;
 
   useEffect(() => {
@@ -75,6 +76,7 @@ const MonacoYamlEditor: React.FC<Props> = props => {
         handleMouseWheel: false,
       },
       tabSize: 2,
+      readOnly: readOnly,
     });
 
     instanceRef.current.editor = editor;
@@ -88,7 +90,7 @@ const MonacoYamlEditor: React.FC<Props> = props => {
       editor.dispose();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [defaultValue, schema, id, getInstance]);
+  }, [defaultValue, schema, id, readOnly, getInstance]);
 
   useEffect(() => {
     const editor = instanceRef.current.editor;

--- a/src/sunmao/components/YamlEditor/YamlEditorComponent.tsx
+++ b/src/sunmao/components/YamlEditor/YamlEditorComponent.tsx
@@ -75,6 +75,7 @@ export type Props = Partial<Static<typeof PropsSchema>> & {
   className?: string;
   height?: string;
   isDefaultCollapsed?: boolean;
+  readOnly?: boolean;
   onChange?: (value: string) => void;
   onValidate?: (valid: boolean, schemaValid: boolean) => void;
   onEditorCreate?: (editor: monaco.editor.ICodeEditor) => void;
@@ -88,7 +89,7 @@ export type Handle = {
 }
 
 export const YamlEditorComponent = forwardRef<Handle, Props>(function YamlEditorComponent(props, ref) {
-  const { title, isDefaultCollapsed, defaultValue = "", height, errorMsgs = [], schema, eleRef, className } = props;
+  const { title, isDefaultCollapsed, defaultValue = "", height, readOnly, errorMsgs = [], schema, eleRef, className } = props;
   const kit = useContext(KitContext);
   const { t } = useTranslation();
   const [isCollapsed, setIsCollapsed] = useState(isDefaultCollapsed);
@@ -281,6 +282,7 @@ export const YamlEditorComponent = forwardRef<Handle, Props>(function YamlEditor
               onEditorCreate={onEditorCreate}
               onBlur={props.onBlur}
               schema={schema}
+              readOnly={readOnly}
             />
           </Suspense>
         )}


### PR DESCRIPTION
服务端 Apply 不需要  kubectl.kubernetes.io/last-applied-configuration annotations，将它移除

![image](https://github.com/webzard-io/dovetail/assets/25414733/fc26bda4-ccbe-404b-8dfc-b0685eb95748)

给 Array Items 和 YAML Editor 添加禁用
