### PR TITLE
fix: fix some issues and change styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-ui/ui",
-  "version": "0.3.47",
+  "version": "0.3.48",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-ui/ui",
-  "version": "0.3.48",
+  "version": "0.3.49",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-ui/ui",
-  "version": "0.3.49",
+  "version": "0.3.50",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-ui/ui",
-  "version": "0.3.46",
+  "version": "0.3.47",
   "files": [
     "dist"
   ],

--- a/src/_internal/atoms/themes/CloudTower/components/Table/Table.style.ts
+++ b/src/_internal/atoms/themes/CloudTower/components/Table/Table.style.ts
@@ -294,6 +294,7 @@ export const TableStyle = css`
           white-space: nowrap;
           text-overflow: ellipsis;
           > span {
+            flex: 1 1;
             overflow: hidden;
             text-overflow: ellipsis;
           }

--- a/src/_internal/molecules/AutoForm/SpecField/SectionTitle.tsx
+++ b/src/_internal/molecules/AutoForm/SpecField/SectionTitle.tsx
@@ -31,12 +31,13 @@ const EditYAMLTextStyle = css`
 `;
 
 type SectionTitleProps = {
-  isDisplayEditorSwitch: boolean;
+  isDisplayEditorSwitch?: boolean;
   sectionTitle?: string;
   editorSwitchTooltip?: string;
   isEnableEditor?: boolean;
   isDisabledSwitchEditor?: boolean;
   onEnableEditorChange?: (checked: boolean) => void;
+  className?: string;
 }
 
 function SectionTitle(props: SectionTitleProps) {
@@ -46,13 +47,14 @@ function SectionTitle(props: SectionTitleProps) {
     editorSwitchTooltip,
     isEnableEditor,
     isDisabledSwitchEditor,
-    onEnableEditorChange
+    className,
+    onEnableEditorChange,
   } = props;
   const { i18n } = useTranslation();
   const kit = useContext(KitContext);
 
   return (
-    <div className={cx(FieldSection, "field-section-title", isDisplayEditorSwitch ? "editor-switch-section-title" : null)}>
+    <div className={cx(FieldSection, "field-section-title", isDisplayEditorSwitch ? "editor-switch-section-title" : null, className)}>
       <span className={cx("section-title-text")}>{sectionTitle}</span>
       {isDisplayEditorSwitch ? (
         <span>

--- a/src/_internal/molecules/Editor.tsx
+++ b/src/_internal/molecules/Editor.tsx
@@ -105,9 +105,7 @@ function Editor(props: EditorProps) {
   return (<>
     {props.widgetOptions?.sectionTitle && <SectionTitle
       sectionTitle={props.widgetOptions?.sectionTitle}
-      isDisplayEditorSwitch
-      isEnableEditor
-      isDisabledSwitchEditor
+      className="editor-switch-section-title"
     />}
     <YamlEditorComponent
       ref={ref}

--- a/src/_internal/organisms/KubectlGetDetail/KubectlGetDetail.tsx
+++ b/src/_internal/organisms/KubectlGetDetail/KubectlGetDetail.tsx
@@ -18,7 +18,7 @@ import styled from "@emotion/styled";
 import { Typo } from "../../atoms/themes/CloudTower/styles/typo.style";
 import ErrorContent from "../../ErrorContent";
 import { Icon, useUIKit } from "@cloudtower/eagle";
-import { ArrowChevronUp16BlueIcon, ArrowChevronDown16BlueIcon } from "@cloudtower/icons-react";
+import { ArrowChevronUp16BoldBlueIcon, ArrowChevronDown16BoldBlueIcon } from "@cloudtower/icons-react";
 import cs from "classnames";
 
 const RowStyle = css`
@@ -105,6 +105,9 @@ const TabWrapper = styled.div`
 `;
 const SectionStyle = css`
   &:not(:last-of-type) {
+    &.section-collapsed {
+      margin-bottom: 8px;
+    }
     margin-bottom: 24px;
   }
 `;
@@ -218,7 +221,7 @@ function DetailSection(props: DetailSectionProps) {
   const [isCollapsed, setIsCollapsed] = useState(false);
 
   return (
-    <div key={section.title} className={SectionStyle}>
+    <div key={section.title} className={cx(SectionStyle, isCollapsed && "section-collapsed")}>
       {section.title ? (
         <div className={SectionHeaderStyle}>
           <div
@@ -230,8 +233,8 @@ function DetailSection(props: DetailSectionProps) {
             section.collapsible ? (
               <UIKit.button type="text" size="small" onClick={() => setIsCollapsed(!isCollapsed)}>
                 {isCollapsed ?
-                  <ArrowChevronUp16BlueIcon /> :
-                  <ArrowChevronDown16BlueIcon />
+                  <ArrowChevronDown16BoldBlueIcon /> :
+                  <ArrowChevronUp16BoldBlueIcon />
                 }
               </UIKit.button>
             ) : null

--- a/src/sunmao/components/KubectlGetTable.tsx
+++ b/src/sunmao/components/KubectlGetTable.tsx
@@ -32,6 +32,13 @@ type Response = {
   error: null | Error;
 };
 
+const EMPTY_VALUES = [
+  undefined,
+  null,
+  "",
+  "-"
+];
+
 const WrapperStyle = css`
   &.table-wrapper.sunmao-cloudtower-table {
     border-top: 0;
@@ -89,6 +96,9 @@ const WrapperStyle = css`
       background: transparent;
     }
   }
+`;
+const EmptyTextStyle = css`
+  color: rgba(0, 21, 64, 0.30);
 `;
 
 const WIDGET_CATEGORY = "Widget";
@@ -630,7 +640,7 @@ export const KubectlGetTable = implementRuntimeComponent({
       });
     }, []);
 
-    const finalColumns = useMemo(()=> columns.map((col, colIndex) => ({
+    const finalColumns = useMemo(() => columns.map((col, colIndex) => ({
       ...col,
       fixed: col.fixed === "none" ? undefined : col.fixed,
       dataIndex: typeof col.dataIndex === "string"
@@ -641,7 +651,11 @@ export const KubectlGetTable = implementRuntimeComponent({
           { ...col, path: col.dataIndex },
           {
             value: value,
-            renderedValue: value ?? "-",
+            renderedValue: <span
+              className={EMPTY_VALUES.includes(value) ? EmptyTextStyle : ""}
+            >
+              {EMPTY_VALUES.includes(value) ? "-" : value}
+            </span>,
             record,
             index,
           },

--- a/src/sunmao/components/YamlEditor/YamlEditorComponent.tsx
+++ b/src/sunmao/components/YamlEditor/YamlEditorComponent.tsx
@@ -106,7 +106,7 @@ export const YamlEditorComponent = forwardRef<Handle, Props>(function YamlEditor
         editorInstance.current?.getModel()?.setValue(value);
       },
       getEditorValue: () => {
-        return editorInstance.current?.getValue() || value || "";
+        return editorInstance.current?.getValue() ?? value ?? "";
       }
     };
   });

--- a/src/sunmao/traits/KubeAPITrait.ts
+++ b/src/sunmao/traits/KubeAPITrait.ts
@@ -137,7 +137,6 @@ export default implementRuntimeTrait({
     ],
   },
 })(() => {
-  const responseMap = new Map();
   const stopMap = new Map();
   const timeMap = new Map();
   const countUpdateMap = new Map();
@@ -189,19 +188,22 @@ export default implementRuntimeTrait({
       // reset last retry's times and timer
       api.resetRetryState();
 
-      const onResponseAndWatchUpdate = (response: UnstructuredList) => {
+      const onListResponse = (response: UnstructuredList) => {
         mergeState({ loading: false, error: null, response });
-        if (!responseMap.has(componentId)) {
-          onResponse?.forEach((handler, index) => {
-            runEventHandler(
-              handler,
-              trait.properties.onResponse,
-              index,
-              services,
-              ""
-            )();
-          });
-        }
+        
+        onResponse?.forEach((handler, index) => {
+          runEventHandler(
+            handler,
+            trait.properties.onResponse,
+            index,
+            services,
+            ""
+          )();
+        });
+      };
+      const onListWatchUpdate = (response: UnstructuredList) => {
+        mergeState({ loading: false, error: null, response });
+        
         onDataUpdate?.forEach((handler, index) => {
           runEventHandler(
             handler,
@@ -211,7 +213,6 @@ export default implementRuntimeTrait({
             ""
           )();
         });
-        responseMap.set(componentId, response);
       };
 
       const stopFn = await api
@@ -224,8 +225,8 @@ export default implementRuntimeTrait({
               )
             ),
           },
-          onResponse: onResponseAndWatchUpdate,
-          onWatchUpdate: onResponseAndWatchUpdate
+          onResponse: onListResponse,
+          onWatchUpdate: onListWatchUpdate
         })
         .catch((err) => {
           mergeState({ loading: false, error: err, response: emptyData });
@@ -321,7 +322,6 @@ export default implementRuntimeTrait({
         ],
         componentDidUnmount: [
           () => {
-            responseMap.delete(componentId);
             stop();
           },
         ],


### PR DESCRIPTION
- 编辑器在空值时返回正确的值
- 修改 KGD 样式
- KubeAPITrait 移除 `responseMap`。之前首次返回和 watch 更新使用的是同一个 handler，所以需要 responseMap 来记录区分是否为首次返回。现在修改为不同的 handler ，不再需要 responseMap
- 隐藏 EditorWidget 的转换开关