### PR TITLE
feat: support specify the apply action and add `setFields` method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-ui/ui",
-  "version": "0.3.52",
+  "version": "0.3.53",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-ui/ui",
-  "version": "0.3.51",
+  "version": "0.3.52",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-ui/ui",
-  "version": "0.3.50",
+  "version": "0.3.51",
   "files": [
     "dist"
   ],

--- a/src/sunmao/components/KubectlApplyForm.tsx
+++ b/src/sunmao/components/KubectlApplyForm.tsx
@@ -18,7 +18,7 @@ import {
   FORM_WIDGET_OPTIONS_MAP,
 } from "../../_internal/molecules/form";
 import { LAYOUT_WIDGETS_MAP } from "../../_internal/molecules/layout";
-import { KubeSdk } from "../../_internal/k8s-api-client/kube-api";
+import { KubeSdk, KubernetesApplyAction } from "../../_internal/k8s-api-client/kube-api";
 import { generateSlotChildren } from "../utils/slot";
 import { immutableSet } from "../utils/object";
 import registry from "../../services/Registry";
@@ -506,6 +506,7 @@ export const KubectlApplyForm = implementRuntimeComponent({
           Type.Array(Type.String()),
           { conditions: [{ key: "strategy", value: "application/json-patch+json" }] }
         ),
+        actions: Type.Array(StringUnion(["create", "patch"])),
       }),
       clearError: Type.Object({}),
       validateForm: Type.Object({}),
@@ -685,7 +686,7 @@ export const KubectlApplyForm = implementRuntimeComponent({
           }
 
           mergeState({
-            isValid: Object.values(result).every(error=> !error),
+            isValid: Object.values(result).every(error => !error),
           });
         },
         nextStep({ disabled }) {
@@ -696,7 +697,7 @@ export const KubectlApplyForm = implementRuntimeComponent({
           }
 
           mergeState({
-            isValid: Object.values(result).every(error=> !error),
+            isValid: Object.values(result).every(error => !error),
           });
 
           if (
@@ -706,7 +707,13 @@ export const KubectlApplyForm = implementRuntimeComponent({
             changeStep(step + 1);
           }
         },
-        async apply({ disabled, transformMap, strategy, replacePaths }) {
+        async apply({
+          disabled,
+          transformMap,
+          strategy,
+          replacePaths,
+          actions
+        }) {
           try {
             let result: Record<string, string[]> = {};
 
@@ -715,7 +722,7 @@ export const KubectlApplyForm = implementRuntimeComponent({
             }
 
             mergeState({
-              isValid: Object.values(result).every(error=> !error),
+              isValid: Object.values(result).every(error => !error),
             });
 
             if (
@@ -747,7 +754,12 @@ export const KubectlApplyForm = implementRuntimeComponent({
                 error: null,
               });
 
-              await sdk.applyYaml(appliedValues, strategy, replacePaths);
+              await sdk.applyYaml(
+                appliedValues,
+                strategy,
+                replacePaths,
+                actions
+              );
 
               mergeState({
                 loading: false,


### PR DESCRIPTION
### `apply` 方法添加 `actions` 参数

当在创建资源时使用相同的名称进行 Apply，会使用 Patch 的方式来修改原有资源，这是不符合预期的。

因此现在支持指定 KAF Apply 的提交方式，在特定的场景下只以指定的方式进行提交。

### KAF 添加 `setFiedls`

方便一次设置多个字段值