### PR TITLE
fix: dont limit the line width of yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-ui/ui",
-  "version": "0.3.53",
+  "version": "0.3.54",
   "files": [
     "dist"
   ],

--- a/src/_internal/molecules/AutoForm/SpecField/FormEditor.tsx
+++ b/src/_internal/molecules/AutoForm/SpecField/FormEditor.tsx
@@ -64,7 +64,7 @@ const FormEditor = React.forwardRef<FormEditorHandle, FormEditorProps>(function 
   const finalErrors = useMemo(() => {
     return isShowError ? [...new Set([...editorErrors, ...errors, ...filedErrors])] : [];
   }, [isShowError, editorErrors, errors, filedErrors]);
-  const defaultEditorValue = useMemo(() => yaml.dump(props.field?.defaultValue || {}), [props.field?.defaultValue]);
+  const defaultEditorValue = useMemo(() => yaml.dump(props.field?.defaultValue || {}, { lineWidth: Number.MAX_SAFE_INTEGER }), [props.field?.defaultValue]);
 
   const validate = useCallback((callback: (errorMsgs: string[], newValue: unknown) => void) => {
     if (editorErrors.length || filedErrors.length) {
@@ -109,7 +109,7 @@ const FormEditor = React.forwardRef<FormEditorHandle, FormEditorProps>(function 
     }
   }, [emitChange, editorErrors.length])
   const changeValue = useCallback(() => {
-    const currentEditorValue = yaml.dump(value);
+    const currentEditorValue = yaml.dump(value, { lineWidth: Number.MAX_SAFE_INTEGER });
 
     if (currentEditorValue !== editorRef.current?.getEditorValue()) {
       editorRef.current?.setEditorValue(currentEditorValue);

--- a/src/_internal/molecules/Editor.tsx
+++ b/src/_internal/molecules/Editor.tsx
@@ -31,7 +31,7 @@ function Editor(props: EditorProps) {
     () => {
       if (field?.defaultValue === undefined) return "";
 
-      return typeof field?.defaultValue === "string" ? field?.defaultValue || "" : yaml.dump(field?.defaultValue || {});
+      return typeof field?.defaultValue === "string" ? field?.defaultValue || "" : yaml.dump(field?.defaultValue || {}, { lineWidth: Number.MAX_SAFE_INTEGER });
     },
     [field?.defaultValue]
   );
@@ -82,7 +82,7 @@ function Editor(props: EditorProps) {
       const valueFromEditor = yaml.load(ref.current?.getEditorValue() || "");
 
       if (!isEqual(value, valueFromEditor)) {
-        const newEditorValue = typeof value === "string" ? value : yaml.dump(value);
+        const newEditorValue = typeof value === "string" ? value : yaml.dump(value, { lineWidth: Number.MAX_SAFE_INTEGER });
 
         ref.current?.setEditorValue(newEditorValue);
         ref.current?.setValue(newEditorValue);


### PR DESCRIPTION
当 YAML 的行字符数超出设置的 lineWidth 时，多行字符串的换行符会解析错误多出一行，因此将 lineWidth 设为最大值防止解析错误。