### PR TITLE
fix: emit chagne event immediately after applying the resource

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-ui/ui",
-  "version": "0.3.54",
+  "version": "0.3.55",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
问题：在一次性 Apply 多个资源后，对应资源的值没有更新为最新 watch 到的值

原因：现在在 Apply 资源成功后会本地将 Apply 的值更新到缓存上，但是时机是等待多个资源都 Apply 成功后才更新，这期间 watch 可能会返回最新的值，导致等待完成后触发更新缓存将 watch 的值覆盖掉

解决：Apply 一个资源成功后立马更新对应资源的缓存，而不是等待所有都成功