### PR TITLE
fix(InputNumber): handle the big number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-ui/ui",
-  "version": "0.3.55",
+  "version": "0.3.56",
   "files": [
     "dist"
   ],

--- a/src/_internal/atoms/kit-context.ts
+++ b/src/_internal/atoms/kit-context.ts
@@ -250,7 +250,8 @@ export type InputProps = Omit<AntdInputProps, "onChange"> & {
   type: AntdInputProps["type"] | "int" | "float";
   onChange?: (
     event: React.ChangeEvent<HTMLInputElement>,
-    value: string | number | undefined
+    value: string | number | undefined,
+    rawValue: string,
   ) => void;
 };
 

--- a/src/_internal/atoms/themes/CloudTower/components/Input/Input.tsx
+++ b/src/_internal/atoms/themes/CloudTower/components/Input/Input.tsx
@@ -199,7 +199,8 @@ type InputProps = Omit<AntdInputProps, "onChange"> & {
   type: AntdInputProps["type"] | "int";
   onChange?: (
     event: React.ChangeEvent<HTMLInputElement>,
-    value: string | number | undefined
+    value: string | number | undefined,
+    rawValue: string,
   ) => void;
 };
 
@@ -223,7 +224,9 @@ const Input: React.FC<InputProps> = ({
       if (props.type === "int") {
         onIntChange(e);
       } else {
-        props.onChange?.(e, e.target.value);
+        const stringValue = e.target.value;
+
+        props.onChange?.(e, stringValue, stringValue);
       }
     },
     [onIntChange, props.type, props.onChange]

--- a/src/_internal/atoms/themes/CloudTower/components/Input/useInt.ts
+++ b/src/_internal/atoms/themes/CloudTower/components/Input/useInt.ts
@@ -5,7 +5,7 @@ type Props = {
   supportNegativeValue?: boolean;
   maximum?: number;
   minimum?: number;
-  onChange?: (e: React.ChangeEvent<HTMLInputElement>, value: string | number) => void;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>, value: string | number, rawValue: string) => void;
   onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
 };
 
@@ -15,14 +15,14 @@ function useInt(props: Props) {
       const value = e.currentTarget.value;
       if (props.supportNegativeValue) {
         if (value === "" || value === "-") {
-          props.onChange?.(e, value);
+          props.onChange?.(e, value, value);
         } else if (/^(-)?\d+$/.test(value)) {
           const v = parseInt(value);
-          props.onChange?.(e, !Number.isNaN(v) ? v : '');
+          props.onChange?.(e, !Number.isNaN(v) ? v : "", value);
         }
       } else if (value === "" || /^\d+$/.test(value)) {
         const v = parseInt(value);
-        props.onChange?.(e, !Number.isNaN(v) ? v : '');
+        props.onChange?.(e, !Number.isNaN(v) ? v : "", value);
       }
     },
     [props.onChange, props.supportNegativeValue]
@@ -33,16 +33,17 @@ function useInt(props: Props) {
       const minimumIsValid = typeof props.minimum === "number";
 
       if (maximumIsValid || minimumIsValid) {
-        const value = parseInt(e.target.value) || 0;
+        const rawValue = e.target.value;
+        const value = parseInt(rawValue) || 0;
         
         if (isNil(value)) {
-          props.onChange?.(e, '');
+          props.onChange?.(e, "", rawValue);
         }
         if (!isNil(value) && maximumIsValid && (props.maximum || 0) < value) {
-          props.onChange?.(e, props.maximum || 0);
+          props.onChange?.(e, props.maximum || 0, rawValue);
         }
         if (!isNil(value) && minimumIsValid && (props.minimum || 0) > value) {
-          props.onChange?.(e, props.minimum || 0);
+          props.onChange?.(e, props.minimum || 0, rawValue);
         }
       }
 

--- a/src/_internal/molecules/InputNumber.tsx
+++ b/src/_internal/molecules/InputNumber.tsx
@@ -47,16 +47,21 @@ const InputNumber = (props: Props) => {
   const [stringValue, setStringValue] = useState(transformValue(props.value + ""));
 
   const onChange = useCallback(
-    (event, newValue) => {
-      const transformedNewValue = unit ? newValue + unit : Number(newValue);
+    (event, newValue, newStringValue) => {
+      const newNumberValue = Number(newValue);
+      const transformedNewValue = unit ? newValue + unit : newNumberValue;
 
-      props.onChange(
-        transformedNewValue,
-        displayValues,
-        props.itemKey,
-        props.path
-      );
-      setStringValue(newValue);
+      // it should only change when the number is safe
+      if (newNumberValue < Number.MAX_SAFE_INTEGER && newNumberValue > Number.MIN_SAFE_INTEGER) {
+        props.onChange(
+          transformedNewValue,
+          displayValues,
+          props.itemKey,
+          props.path
+        );
+      }
+
+      setStringValue(newStringValue);
     },
     [setStringValue, props, displayValues, unit]
   );


### PR DESCRIPTION
问题：修复当数值过大转换成科学计数法时，无法在 onBlur 时转换为限制的最大值的问题。

解决办法：当数值超出安全值时不再提交实际的数字值，只改变字符串的值，等 onBlur 后修改为正确的数值再进行向上提交