### PR TITLE
feat(KAF): add the readonly and readonlyTex props 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-ui/ui",
-  "version": "0.3.57",
+  "version": "0.3.58",
   "files": [
     "dist"
   ],

--- a/src/_internal/molecules/ArrayItems.tsx
+++ b/src/_internal/molecules/ArrayItems.tsx
@@ -152,7 +152,7 @@ const ArrayItems = (props: Props) => {
               path={path.concat(`.${itemIndex}`)}
               level={level + 1}
               widgetOptions={
-                { disabled: widgetOptions?.disabled, ...(field?.subItem?.widgetOptions || {}) } || 
+                { disabled: widgetOptions?.disabled, ...(field?.subItem?.widgetOptions || {}) } ||
                 { disabled: widgetOptions?.disabled }
               }
               onChange={(
@@ -184,8 +184,7 @@ const ArrayItems = (props: Props) => {
       {widgetOptions.helper && value.length ? (
         <HelperText>{widgetOptions.helper}</HelperText>
       ) : null}
-      {widgetOptions.addable !== false && !widgetOptions?.disabled &&
-        value.length < (widgetOptions.maxLength || Number.MAX_SAFE_INTEGER) ? (
+      {widgetOptions.addable !== false && !widgetOptions?.disabled ? (
         <div style={{ marginTop: widgetOptions.helper ? 0 : "16px" }}>
           {widgetOptions.addedButtonIcon ? (
             <Icon type={widgetOptions.addedButtonIcon as IconTypes}></Icon>
@@ -195,6 +194,7 @@ const ArrayItems = (props: Props) => {
             hoverPrefixIcon="1-plus-add-create-new-16-blue"
             className={AddedButtonStyle}
             size="small"
+            disabled={value.length >= (widgetOptions.maxLength || Number.MAX_SAFE_INTEGER)}
             onClick={() => {
               const defaultValue =
                 widgetOptions.useFirstAsDefaultValue ? props.field?.defaultValue?.[0] ?? generateFromSchema(itemSpec) : generateFromSchema(itemSpec);

--- a/src/_internal/molecules/AutoForm/SpecField/index.tsx
+++ b/src/_internal/molecules/AutoForm/SpecField/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useContext, useRef } from "react";
 import isEmpty from "lodash/isEmpty";
+import { Typo } from "../../../atoms/themes/CloudTower/styles/typo.style";
 // TODO: use kit context when I have time:)
 import { Col } from "antd";
 import { JSONSchema7 } from "json-schema";
@@ -278,11 +279,14 @@ const SpecField: React.FC<SpecFieldProps> = (props) => {
           >
             <kit.Tooltip title={fieldOrItem?.tooltip} placement="topLeft">
               <span>
-                {slot?.(
-                  slotProps,
-                  FieldComponent,
-                  `filed_${path}`
-                ) || FieldComponent}
+                {fieldOrItem?.readonly ? <span className={Typo.Label.l2_regular} style={{ color: "#00122E" }}>{fieldOrItem.readonlyText || value}</span> : null}
+                <span style={{ display: fieldOrItem?.readonly ? "none" : "inline" }}>
+                  {(slot?.(
+                    slotProps,
+                    FieldComponent,
+                    `filed_${path}`
+                  ) || FieldComponent)}
+                </span>
               </span>
             </kit.Tooltip>
           </FormItem>

--- a/src/_internal/organisms/KubectlApplyForm/type.ts
+++ b/src/_internal/organisms/KubectlApplyForm/type.ts
@@ -17,6 +17,8 @@ export type Field = {
     | "rules"
     | "disabledValidation"
     | "tooltip"
+    | "readonly"
+    | "readonlyText"
   > & {
     type?: undefined;
   };
@@ -53,6 +55,8 @@ export type Field = {
   editorHeight?: string;
   editorFormatError?: string;
   editorSchemaError?: string;
+  readonly?: boolean;
+  readonlyText?: string;
 };
 
 export type FormItemData = (Field | Record<string, unknown>) & {
@@ -63,26 +67,26 @@ export type TransformedField = Field & { dataPath: string; value: any };
 
 export type Layout =
   | {
-      type: "simple";
+    type: "simple";
+    fields: Field[];
+  }
+  | {
+    type: "tabs";
+    tabs: {
+      title: string;
       fields: Field[];
-    }
+    }[];
+  }
   | {
-      type: "tabs";
-      tabs: {
-        title: string;
-        fields: Field[];
-      }[];
-    }
-  | {
-      type: "wizard";
-      steps: {
-        title: string;
-        fields: Field[];
-        disabled?: boolean;
-        prevText?: string;
-        nextText?: string;
-      }[];
-    };
+    type: "wizard";
+    steps: {
+      title: string;
+      fields: Field[];
+      disabled?: boolean;
+      prevText?: string;
+      nextText?: string;
+    }[];
+  };
 
 export type Events = {
   remove: {

--- a/src/sunmao/components/KubectlApplyForm.tsx
+++ b/src/sunmao/components/KubectlApplyForm.tsx
@@ -98,6 +98,16 @@ const UiConfigFieldSpecProperties = {
     category: PRESET_PROPERTY_CATEGORY.Basic,
     default: true,
   }),
+  readonly: Type.Boolean({
+    title: "Readonly",
+    category: PRESET_PROPERTY_CATEGORY.Basic,
+    default: false,
+  }),
+  readonlyText: Type.String({
+    title: "Readonly text",
+    category: PRESET_PROPERTY_CATEGORY.Basic,
+    default: false,
+  }),
   helperText: Type.String({
     title: "Helper text",
     conditions: FIELD_CONDITIONS,


### PR DESCRIPTION
KAF 支持设置部分字段为只读，可以在编辑场景使用。只读字段会给原本要渲染的表单项组件设置 `display: none` 而不是不渲染出来，便于可以从表单项组件中读取所需信息。

比如一些获取远程数据的 Select 组件，表单中的值可能只有 id，但却需要展示名称，这时候就可以从组件中读取数据。