### PR TITLE
feat: generating the unique IDs as the component keys in array

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,12 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "jsxBracketSameLine": false,
+  "arrowParens": "avoid",
+  "endOfLine": "lf",
+  "printWidth": 90
+}

--- a/src/_internal/molecules/ArrayCards.tsx
+++ b/src/_internal/molecules/ArrayCards.tsx
@@ -11,6 +11,7 @@ import { generateFromSchema } from "../utils/schema";
 import { JSONSchema7 } from "json-schema";
 import { useTranslation } from "react-i18next";
 import { cloneDeep, set } from "lodash";
+import { defineId, ID_PROP } from "./../utils/id";
 
 const CardStyle = css`
   margin-bottom: 16px;
@@ -104,6 +105,8 @@ const ArrayCards = (props: Props) => {
   return (
     <>
       {(value || []).map((itemValue, itemIndex) => {
+        defineId(itemValue);
+
         return (
           <Card
             {...props}
@@ -113,6 +116,7 @@ const ArrayCards = (props: Props) => {
             spec={itemSpec as JSONSchema7}
             superiorKey={`${props.field?.key}-${itemIndex}`}
             index={itemIndex}
+            id={itemValue[ID_PROP]}
             error={errorInfo instanceof Array ? errorInfo[itemIndex] : ""}
             widgetOptions={{
               ...widgetOptions,

--- a/src/_internal/molecules/ArrayGroups.tsx
+++ b/src/_internal/molecules/ArrayGroups.tsx
@@ -16,6 +16,7 @@ import { StringUnion } from "@sunmao-ui/runtime";
 import { set } from "lodash";
 import { COMMON_ARRAY_OPTIONS } from "./ArrayItems";
 import { Typo } from "../atoms/themes/CloudTower/styles/typo.style";
+import { defineId, ID_PROP } from "../utils/id";
 
 const GroupStyle = css`
   &.dovetail-ant-collapse {
@@ -125,15 +126,18 @@ const ArrayGroups = (props: Props) => {
   return (
     <>
       {(value || []).map((itemValue, itemIndex) => {
+        defineId(itemValue);
+
         return (
           <Group
             {...props}
             className={GroupStyle}
-            key={widgetOptions.itemKey ? itemValue[widgetOptions.itemKey] || itemIndex : itemIndex}
+            key={widgetOptions.itemKey ? (itemValue[widgetOptions.itemKey] || itemValue[ID_PROP] || itemIndex) : (itemValue[ID_PROP] || itemIndex)}
             value={itemValue}
             spec={itemSpec as JSONSchema7}
             superiorKey={`${props.field?.key}-${itemIndex}`}
             index={itemIndex}
+            id={itemValue[ID_PROP]}
             error={errorInfo instanceof Array ? errorInfo[itemIndex] : ""}
             widgetOptions={{
               ...widgetOptions,

--- a/src/_internal/molecules/AutoForm/SpecField/index.tsx
+++ b/src/_internal/molecules/AutoForm/SpecField/index.tsx
@@ -25,6 +25,7 @@ import FormItem from "./FormItem";
 import FormEditor, { FormEditorHandle } from "./FormEditor";
 import { useTranslation } from "react-i18next";
 import SectionTitle from "./SectionTitle";
+import { ID_PROP } from "../../../utils/id";
 
 function shouldDisplayDescription(spec: JSONSchema7): boolean {
   if (spec.type === "object") {
@@ -79,6 +80,7 @@ const SpecField: React.FC<SpecFieldProps> = (props) => {
     error,
     index,
     enabledEditorMap,
+    id,
     setEnabledEditorMap,
     slot,
     helperSlot,
@@ -86,7 +88,6 @@ const SpecField: React.FC<SpecFieldProps> = (props) => {
     onChange,
     onDisplayValuesChange,
   } = props;
-  const { i18n } = useTranslation();
   let { widgetOptions = {} } = props;
   const editorRef = useRef<FormEditorHandle>(null);
   const kit = useContext(KitContext);
@@ -289,7 +290,8 @@ const SpecField: React.FC<SpecFieldProps> = (props) => {
                   {(slot?.(
                     slotProps,
                     FieldComponent,
-                    `filed_${path}`
+                    `filed_${path}`,
+                    id,
                   ) || FieldComponent)}
                 </span>
               </span>

--- a/src/_internal/molecules/AutoForm/widget.ts
+++ b/src/_internal/molecules/AutoForm/widget.ts
@@ -1,5 +1,9 @@
 import { JSONSchema7 } from "json-schema";
-import type { Field, Services, FormItemData } from "../../organisms/KubectlApplyForm/type";
+import type {
+  Field,
+  Services,
+  FormItemData,
+} from "../../organisms/KubectlApplyForm/type";
 
 type WidgetOptions = Partial<{
   displayLabel: boolean;
@@ -10,17 +14,15 @@ type WidgetOptions = Partial<{
 type SlotFunction = (
   props: FormItemData,
   fallback: React.ReactNode,
-  key: string
+  key: string,
+  id?: string,
 ) => React.ReactNode;
 
-export type WidgetProps<
-  Value = any,
-  WidgetOptions = Record<string, unknown>
-> = {
+export type WidgetProps<Value = any, WidgetOptions = Record<string, unknown>> = {
   services: Services;
   basePath: string;
   field?: Field;
-  item?: Field["subItem"]
+  item?: Field["subItem"];
   itemKey: string;
   spec: JSONSchema7;
   widget?: string;
@@ -29,11 +31,12 @@ export type WidgetProps<
   path: string;
   superiorKey?: string;
   index?: number;
+  id?: string;
   error?: string | string[] | Record<string, string>;
   value: Value;
   displayValues: Record<string, unknown>;
   enabledEditorMap: Record<string, boolean>;
-  setEnabledEditorMap: (newMap: Record<string, boolean>)=> void;
+  setEnabledEditorMap: (newMap: Record<string, boolean>) => void;
   onChange: (
     newValue: Value,
     displayValues: Record<string, unknown>,
@@ -44,6 +47,6 @@ export type WidgetProps<
   slot?: SlotFunction;
   helperSlot?: SlotFunction;
   labelSlot?: SlotFunction;
-  setWidgetErrors: (errors: string[])=> void;
+  setWidgetErrors: (errors: string[]) => void;
   specsArray: Record<string, { spec: JSONSchema7 }>[];
 };

--- a/src/_internal/utils/id.ts
+++ b/src/_internal/utils/id.ts
@@ -1,0 +1,25 @@
+export const ID_PROP = "__id__"
+
+function uuidv4() {
+  if (typeof crypto !== "undefined" && crypto.getRandomValues) {
+    return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, c =>
+      (+c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> +c / 4).toString(16)
+    );
+  } else {
+    return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
+      const r = Math.random() * 16 | 0,
+        v = c == "x" ? r : (r & 0x3 | 0x8);
+      return v.toString(16);
+    });
+  }
+}
+
+export function defineId(object: Record<string, unknown>, id?: string) {
+  if (object[ID_PROP]) return;
+
+  Object.defineProperty(object, ID_PROP, {
+    value: id || uuidv4(),
+    enumerable: false,
+    writable: false,
+  })
+}


### PR DESCRIPTION
## 背景
目前 KAF 在遍历数组字段时默认用的是 index 作为组件的 key，这样在删除数组项时其实销毁的是最后一个组件，而不是删除项对应的组件。

比如，有数组 [0, 1, 2] 和对应的组件 [a(0), b(1), c(2)]（a, b, c 均为同一组件的不同实例，括号中的为它们的 key），删除第 2 项（1）时，数组变为 [0, 2]，组件变为 [a(0), b(1)]，因为它们使用索引作为 key，a、b 组件的 key 都没有变化被保留下来。

没有销毁对应的组件可能会导致一些意外的问题，因为有些状态是保存在组件内部的，而不是放在 KAF 中。

## 解决方案
不再默认使用索引作为 key，而是生成一个唯一的 id 作为 key，id 将会被保存到数组项的属性中保存，并设置 `enumerable: false` 防止外部读取导致提交表单时有多余的值。