### PR TITLE
feat: kaf field support custom test id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-ui/ui",
-  "version": "0.3.61",
+  "version": "0.3.61-hotfix.0",
   "files": [
     "dist"
   ],

--- a/src/_internal/molecules/AutoForm/SpecField/index.tsx
+++ b/src/_internal/molecules/AutoForm/SpecField/index.tsx
@@ -275,7 +275,7 @@ const SpecField: React.FC<SpecFieldProps> = (props) => {
             spec={spec}
             error={typeof finalError === "string" ? finalError : ""}
             widgetErrors={widgetErrors}
-            testId={`${path}-${transformedField?.key || ""}`}
+            testId={field?.customTestId || `${path}-${transformedField?.key || ""}`}
           >
             <kit.Tooltip title={fieldOrItem?.tooltip} placement="topLeft">
               <span>

--- a/src/_internal/organisms/KubectlApplyForm/type.ts
+++ b/src/_internal/organisms/KubectlApplyForm/type.ts
@@ -57,6 +57,7 @@ export type Field = {
   editorSchemaError?: string;
   readonly?: boolean;
   readonlyText?: string;
+  customTestId?: string;
 };
 
 export type FormItemData = (Field | Record<string, unknown>) & {


### PR DESCRIPTION
有的场景下需要支持传入自定义的testId，从而避免field的path显示在DOM中