### PR TITLE
fix: fix the issues of defining id for the array items

### DIFF
--- a/src/_internal/molecules/AutoForm/ObjectField.tsx
+++ b/src/_internal/molecules/AutoForm/ObjectField.tsx
@@ -8,6 +8,7 @@ import type { Field } from "../../organisms/KubectlApplyForm/type";
 import { isObject } from "lodash";
 import { JSONSchema7 } from "json-schema";
 import { immutableSet } from "../../../sunmao/utils/object";
+import { defineId, ID_PROP } from "../../utils/id";
 
 export function resolveSubFields(props: WidgetProps) {
   const { specsArray, field, spec, value, path, level, error, widgetOptions, onChange } =
@@ -43,7 +44,7 @@ export function resolveSubFields(props: WidgetProps) {
           }
           field={subField}
           widget={subField.widget}
-          widgetOptions={{ disabled: widgetOptions?.disabled, ...subField.widgetOptions}}
+          widgetOptions={{ disabled: widgetOptions?.disabled, ...subField.widgetOptions }}
           key={subField.key || subField.path}
           spec={subSpec}
           path={path.concat(isLayout ? subField.path : `.${subField.path}`)}
@@ -54,6 +55,10 @@ export function resolveSubFields(props: WidgetProps) {
               onChange(newValue, displayValues, key, dataPath);
             } else {
               const result = immutableSet(value, subField.path, newValue);
+
+              if (value[ID_PROP]) {
+                defineId(result, value[ID_PROP]);
+              }
 
               onChange(result, displayValues, key, dataPath);
             }

--- a/src/_internal/utils/id.ts
+++ b/src/_internal/utils/id.ts
@@ -1,3 +1,5 @@
+import { isObject } from "lodash";
+
 export const ID_PROP = "__id__"
 
 function uuidv4() {
@@ -15,7 +17,7 @@ function uuidv4() {
 }
 
 export function defineId(object: Record<string, unknown>, id?: string) {
-  if (object[ID_PROP]) return;
+  if (!isObject(object) || object[ID_PROP]) return;
 
   Object.defineProperty(object, ID_PROP, {
     value: id || uuidv4(),

--- a/src/sunmao/components/KubectlApplyForm.tsx
+++ b/src/sunmao/components/KubectlApplyForm.tsx
@@ -676,20 +676,26 @@ export const KubectlApplyForm = implementRuntimeComponent({
     useEffect(() => {
       subscribeMethods({
         setField({ fieldPath, value: fieldValue, displayValue }) {
-          const oldValue = get(values, fieldPath);
           const finalFieldValue =
             fieldValue && typeof fieldValue === "object"
               ? cloneDeep(fieldValue)
               : fieldValue;
-          const newValues = immutableSet(valuesRef.current, fieldPath, finalFieldValue) as any[];
+          const newValues = immutableSet(
+            valuesRef.current,
+            fieldPath,
+            finalFieldValue,
+            (value, oldValue) => {
+              if (oldValue && typeof oldValue === "object" && oldValue[ID_PROP]) {
+                defineId(value, oldValue[ID_PROP]);
+              }
+
+              return value;
+            }
+          ) as any[];
           const newDisplayValues = {
             ...displayValuesRef.current,
             [fieldPath]: displayValue,
           };
-
-          if (oldValue && typeof oldValue === "object" && oldValue[ID_PROP]) {
-            defineId(finalFieldValue, oldValue[ID_PROP]);
-          }
 
           setValues(newValues);
           mergeDisplayValues(newDisplayValues);
@@ -707,21 +713,27 @@ export const KubectlApplyForm = implementRuntimeComponent({
             displayValues: Record<string, any>;
           }, { fieldPath, value: fieldValue, displayValue }) => {
             const { values, displayValues } = result;
-            const oldValue = get(values, fieldPath);
             const finalFieldValue =
               fieldValue && typeof fieldValue === "object"
                 ? cloneDeep(fieldValue)
                 : fieldValue;
 
-            const newValues = immutableSet(values, fieldPath, finalFieldValue) as any[];
+            const newValues = immutableSet(
+              values,
+              fieldPath,
+              finalFieldValue,
+              (value, oldValue) => {
+                if (oldValue && typeof oldValue === "object" && oldValue[ID_PROP]) {
+                  defineId(value, oldValue[ID_PROP]);
+                }
+
+                return value;
+              }
+            ) as any[];
             const newDisplayValues = {
               ...displayValues,
               [fieldPath]: displayValue,
             };
-
-            if (oldValue && typeof oldValue === "object" && oldValue[ID_PROP]) {
-              defineId(finalFieldValue, oldValue[ID_PROP]);
-            }
 
             return {
               values: newValues,

--- a/src/sunmao/components/KubectlApplyForm.tsx
+++ b/src/sunmao/components/KubectlApplyForm.tsx
@@ -770,7 +770,9 @@ export const KubectlApplyForm = implementRuntimeComponent({
           }
 
           mergeState({
-            isValid: Object.values(result).every(error => !error),
+            isValid: Object.values(result).every(
+              (messages) => messages.length === 0
+            ),
           });
         },
         nextStep({ disabled }) {
@@ -781,7 +783,9 @@ export const KubectlApplyForm = implementRuntimeComponent({
           }
 
           mergeState({
-            isValid: Object.values(result).every(error => !error),
+            isValid: Object.values(result).every(
+              (messages) => messages.length === 0
+            ),
           });
 
           if (
@@ -805,15 +809,16 @@ export const KubectlApplyForm = implementRuntimeComponent({
               result = ref.current.validate();
             }
 
+            const isValid = Object.values(result).every(
+              (messages) => messages.length === 0
+            );
+
             mergeState({
-              isValid: Object.values(result).every(error => !error),
+              isValid,
             });
 
             if (
-              Object.values(result).every(
-                (messages) => messages.length === 0
-              ) &&
-              !disabled
+              isValid && !disabled
             ) {
               const sdk = new KubeSdk({
                 basePath,

--- a/src/sunmao/traits/SyncKubectlApplyForm.tsx
+++ b/src/sunmao/traits/SyncKubectlApplyForm.tsx
@@ -46,8 +46,8 @@ export default implementRuntimeTrait({
           componentId,
           name: setValueMethod,
           parameters: formValue,
-          eventType: '',
-          triggerId: ''
+          eventType: "",
+          triggerId: ""
         });
       }
 

--- a/src/sunmao/utils/object.ts
+++ b/src/sunmao/utils/object.ts
@@ -3,7 +3,8 @@ import { first } from "lodash";
 export function immutableSet<T>(
   value: T,
   path: string,
-  propertyValue: any
+  propertyValue: any,
+  handleValue?: (value: any, oldValue: any) => any
 ): T | Record<string, any> {
   if (value !== undefined && value instanceof Object === false) return value;
 
@@ -16,13 +17,15 @@ export function immutableSet<T>(
     object instanceof Array
       ? [...object]
       : {
-          ...object,
-        };
+        ...object,
+      };
 
   if (nextPath) {
-    result[key] = immutableSet(oldValue, nextPath, propertyValue);
+    const newValue = immutableSet(oldValue, nextPath, propertyValue, handleValue);
+
+    result[key] = handleValue ? handleValue(newValue, oldValue) : newValue;
   } else {
-    result[key] = propertyValue;
+    result[key] = handleValue ? handleValue(propertyValue, oldValue) : propertyValue;
   }
 
   return result;


### PR DESCRIPTION
resolveSubFields 中当对象值改变的时候，也需要为它付上原来的 id ，防止生成新的 id。

setField 时需要给赋值所在路径上所遍历的所有对象附上原来的 id，而不只是当前设置值的字段