### PR TITLE
fix: enhance MonacoYamlEditor with schema map

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-ui/ui",
-  "version": "0.4.6-alpha.1",
+  "version": "0.4.6-alpha.2",
   "sideEffects": false,
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovetail-ui/ui",
-  "version": "0.4.5",
+  "version": "0.4.6-alpha.0",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@dovetail-ui/ui",
-  "version": "0.4.6-alpha.0",
+  "version": "0.4.6-alpha.1",
+  "sideEffects": false,
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "files": [
     "dist"
   ],
-  "module": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "main": "./dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
-import { libs, dependencies } from "./sunmao/lib";
+import { libs } from "./sunmao/lib";
+import { dependencies } from "./sunmao/app";
 import registerSunmaoApp from "./SunmaoApp";
 import lcm from "./sunmao/lcm.json";
 import fiddle from "./sunmao/fiddle.json";

--- a/src/VisualEditor.tsx
+++ b/src/VisualEditor.tsx
@@ -1,4 +1,5 @@
-import { libs, dependencies } from "./sunmao/lib";
+import { libs } from "./sunmao/lib";
+import { dependencies } from "./sunmao/app";
 import registerSunmaoEditor from "./SunmaoEditor";
 import "@sunmao-ui/editor/dist/index.css";
 import "./i18n";

--- a/src/declarations/window.d.ts
+++ b/src/declarations/window.d.ts
@@ -1,5 +1,10 @@
 interface Window {
   MonacoEnvironment: {
-    getWorker: (moduleId: unknown, label: string)=> unknown;
+    getWorker: (moduleId: unknown, label: string) => unknown;
   }
+  _MonacoSchemaMap: Map<string, {
+    uri: string;
+    fileMatch: string[];
+    schema: JSONSchema7;
+  }>;
 }

--- a/src/locales/zh-CN/dovetail.json
+++ b/src/locales/zh-CN/dovetail.json
@@ -81,7 +81,7 @@
   "view_changes": "查看改动",
   "back_to_edit": "编辑",
   "configure_file": "配置内容",
-  "yaml_format_wrong": "配置内容不是有效的 yaml 格式。",
+  "yaml_format_wrong": "配置内容不是有效的 YAML 格式。",
   "yaml_value_wrong": "配置内容中存在不合法的值。",
   "edit_yaml": "编辑 YAML",
   "copied": "已复制",

--- a/src/sunmao/app.ts
+++ b/src/sunmao/app.ts
@@ -1,0 +1,12 @@
+const yaml = import.meta.glob("./dependencies/yaml/*.yaml", {
+  as: "raw",
+});
+
+export const dependencies = {
+  yaml: Object.keys(yaml).reduce<Record<string, string>>((prev, cur) => {
+    prev[cur.replace("./dependencies/yaml/", "").replace(".yaml", "")] = yaml[
+      cur
+    ] as unknown as string;
+    return prev;
+  }, {}),
+};

--- a/src/sunmao/components/YamlEditor/MonacoYamlEditor.tsx
+++ b/src/sunmao/components/YamlEditor/MonacoYamlEditor.tsx
@@ -37,17 +37,32 @@ if (!import.meta.env.PROD) {
   };
 }
 
-const schemaMap = new Map();
-
 const MonacoYamlEditor: React.FC<Props> = props => {
   const ref = useRef<HTMLDivElement>(null);
-  const instanceRef = useRef<{ editor: monaco.editor.IStandaloneCodeEditor | null }>({ editor: null });
-  const { defaultValue, id, height, readOnly, onChange, onValidate, getInstance, onEditorCreate, onBlur, schema } = props;
+  const instanceRef = useRef<{ editor: monaco.editor.IStandaloneCodeEditor | null }>({
+    editor: null,
+  });
+  const {
+    defaultValue,
+    id,
+    height,
+    readOnly,
+    onChange,
+    onValidate,
+    getInstance,
+    onEditorCreate,
+    onBlur,
+    schema,
+  } = props;
   const uri = id ? monaco.Uri.parse(`${id}.yaml`) : undefined;
 
   useEffect(() => {
+    if (!window._MonacoSchemaMap) {
+      window._MonacoSchemaMap = new Map();
+    }
+
     if (schema) {
-      schemaMap.set(id, {
+      window._MonacoSchemaMap.set(id || "", {
         // Id of the first schema
         uri: String(uri),
         // Associate with our model
@@ -55,7 +70,7 @@ const MonacoYamlEditor: React.FC<Props> = props => {
         schema,
       });
     }
-    const schemas = [...schemaMap.values()];
+    const schemas = [...window._MonacoSchemaMap.values()];
     // config monaco yaml
     setDiagnosticsOptions({
       enableSchemaRequest: false,
@@ -85,10 +100,10 @@ const MonacoYamlEditor: React.FC<Props> = props => {
 
     return () => {
       instanceRef.current.editor = null;
-      schemaMap.delete(id);
+      window._MonacoSchemaMap.delete(id || "");
       model.dispose();
       editor.dispose();
-    }
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [defaultValue, schema, id, readOnly, getInstance]);
 
@@ -97,14 +112,14 @@ const MonacoYamlEditor: React.FC<Props> = props => {
 
     if (editor) {
       const stop = editor.onDidChangeModelContent(() => {
-        ReactDOM.unstable_batchedUpdates(()=> {
+        ReactDOM.unstable_batchedUpdates(() => {
           onChange(editor.getValue());
         });
       });
 
       return () => {
         stop.dispose();
-      }
+      };
     }
   }, [onChange, instanceRef.current.editor]);
 
@@ -112,12 +127,15 @@ const MonacoYamlEditor: React.FC<Props> = props => {
     const editor = instanceRef.current.editor;
 
     if (editor) {
-      const stop = monaco.editor.onDidChangeMarkers((uri) => {
+      const stop = monaco.editor.onDidChangeMarkers(uri => {
         const model = instanceRef.current.editor?.getModel();
         const currentEditorUri = model?.uri;
 
         if (model && uri.toString() === currentEditorUri?.toString()) {
-          const marks = monaco.editor.getModelMarkers({ owner: "yaml", resource: currentEditorUri });
+          const marks = monaco.editor.getModelMarkers({
+            owner: "yaml",
+            resource: currentEditorUri,
+          });
           const yamlMarks = marks.filter(m => m.source === "YAML");
           const schemaMarks = marks.filter(m => m.source !== "YAML");
           const yamlValid = yamlMarks.length === 0;
@@ -125,17 +143,20 @@ const MonacoYamlEditor: React.FC<Props> = props => {
 
           onValidate(yamlValid, schemaValid);
 
-          if (marks.some(mark=> mark.source?.includes("yaml-schema"))) {
-            monaco.editor.setModelMarkers(model, "yaml", marks.map(mark=> ({ ...mark, source: "", resource: {} })));
+          if (marks.some(mark => mark.source?.includes("yaml-schema"))) {
+            monaco.editor.setModelMarkers(
+              model,
+              "yaml",
+              marks.map(mark => ({ ...mark, source: "", resource: {} }))
+            );
           }
         }
-      })
+      });
 
       return () => {
         stop.dispose();
       };
     }
-
   }, [onValidate, instanceRef.current.editor]);
 
   useEffect(() => {
@@ -143,7 +164,7 @@ const MonacoYamlEditor: React.FC<Props> = props => {
 
     if (editor) {
       const stop = editor.onDidBlurEditorWidget(() => {
-        ReactDOM.unstable_batchedUpdates(()=> {
+        ReactDOM.unstable_batchedUpdates(() => {
           onBlur?.();
         });
       });
@@ -159,26 +180,30 @@ const MonacoYamlEditor: React.FC<Props> = props => {
     const stops: monaco.IDisposable[] = [];
 
     if (editor) {
-      stops.push(editor.onDidFocusEditorWidget(() => {
-        editor.updateOptions({
-          scrollbar: {
-            handleMouseWheel: true,
-          }
+      stops.push(
+        editor.onDidFocusEditorWidget(() => {
+          editor.updateOptions({
+            scrollbar: {
+              handleMouseWheel: true,
+            },
+          });
         })
-      }));
-      stops.push(editor.onDidBlurEditorWidget(() => {
-        editor.updateOptions({
-          scrollbar: {
-            handleMouseWheel: false,
-          }
+      );
+      stops.push(
+        editor.onDidBlurEditorWidget(() => {
+          editor.updateOptions({
+            scrollbar: {
+              handleMouseWheel: false,
+            },
+          });
         })
-      }));
+      );
     }
 
     return () => {
       stops.forEach(stop => stop.dispose());
-    }
-  }, [instanceRef.current.editor])
+    };
+  }, [instanceRef.current.editor]);
 
   return (
     <div

--- a/src/sunmao/components/YamlEditor/MonacoYamlEditor.tsx
+++ b/src/sunmao/components/YamlEditor/MonacoYamlEditor.tsx
@@ -92,6 +92,7 @@ const MonacoYamlEditor: React.FC<Props> = props => {
       },
       tabSize: 2,
       readOnly: readOnly,
+      theme: "vs",
     });
 
     instanceRef.current.editor = editor;

--- a/src/sunmao/lib.ts
+++ b/src/sunmao/lib.ts
@@ -99,15 +99,3 @@ export const libs: SunmaoLib[] = [
   },
 ];
 
-const yaml = import.meta.glob("./dependencies/yaml/*.yaml", {
-  as: "raw",
-});
-
-export const dependencies = {
-  yaml: Object.keys(yaml).reduce<Record<string, string>>((prev, cur) => {
-    prev[cur.replace("./dependencies/yaml/", "").replace(".yaml", "")] = yaml[
-      cur
-    ] as unknown as string;
-    return prev;
-  }, {}),
-};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,12 +8,17 @@ import linariaVitePlugin from "./tools/linaria-vite-plugin";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { getProxyConfig, applyK8sYamlPlugin } from "./tools/proxy-k8s";
 import monacoEditorPlugin from "vite-plugin-monaco-editor";
+import pkg from './package.json';
 
 const globalSassPath = path.resolve(
   __dirname,
   "./src/_internal/atoms/themes/CloudTower/styles/variables.scss"
 );
 const globalSass = fs.readFileSync(globalSassPath, "utf-8");
+const external = [
+  ...Object.keys(pkg.dependencies || {}),
+  ...Object.keys(pkg.peerDependencies || {})
+]
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -25,22 +30,11 @@ export default defineConfig({
         widgets: path.resolve(__dirname, "src/widgets.ts"),
       },
       name: "Kui",
-      fileName: (format, entryName) => `${entryName}.js`,
+      fileName: (format, entryName) => `${entryName}.${format === 'es' ? 'mjs' : 'js'}`,
       formats: ["es", "cjs"],
     },
     rollupOptions: {
-      external: [
-        "react",
-        "react-dom",
-        "semver",
-        "@sunmao-ui/core",
-        "@sunmao-ui/runtime",
-        "@sunmao-ui/editor-sdk",
-        "chakra-react-select",
-        "monaco-editor",
-        "monaco-yaml",
-        "@cloudtower/eagle"
-      ],
+      external,
     },
   },
   server: {


### PR DESCRIPTION
由于 Monaco 的 setDiagnosticsOptions 是设置全局配置的，不同项目间多次调用 setDiagnosticsOptions 会有冲突问题。

现在把 schemaMap 移到 window 下供其他项目获取，设置完整的 schemas。

另外优化下打包，external 改为所有外部依赖项，esm 文件后缀改为 `.mjs`